### PR TITLE
Integrate new Avail-SubXt version

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,4 +1,4 @@
-name: Polygon Avail Light CI
+name: Avail Light CI
 on:
   push:
     branches:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avail-light"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "async-std",
@@ -651,6 +651,7 @@ dependencies = [
 [[package]]
 name = "avail-subxt"
 version = "0.2.1"
+source = "git+https://github.com/availproject/avail.git?tag=v1.6.0#99b85257d6b5bb3fa3051b1c05d30d42f7471a7e"
 dependencies = [
  "anyhow",
  "curve25519-dalek 2.1.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
 
 [[package]]
+name = "array-init"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,7 +635,6 @@ dependencies = [
  "serde_json",
  "sp-core 6.0.0",
  "structopt",
- "subxt",
  "tempdir",
  "test-case",
  "thiserror",
@@ -643,16 +651,19 @@ dependencies = [
 [[package]]
 name = "avail-subxt"
 version = "0.2.1"
-source = "git+https://github.com/availproject/avail.git?tag=v1.5.0#204f5d754f887fcb03d0a08758ba0fbdd688b28e"
 dependencies = [
  "anyhow",
+ "curve25519-dalek 2.1.3",
  "derive_more",
  "futures",
+ "hex",
  "jsonrpsee",
  "num_enum",
  "parity-scale-codec",
  "scale-info",
+ "schnorrkel",
  "serde",
+ "serde-hex",
  "sp-core 16.0.0",
  "structopt",
  "subxt",
@@ -3074,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "kate-recovery"
 version = "0.8.1"
-source = "git+https://github.com/availproject/avail-core.git?tag=kate-recovery/v0.8.1#dc5ce94b221bfd85debe9cd0599da527bd4d1207"
+source = "git+https://github.com/availproject/avail-core?tag=da-primitives/v0.4.6#6468206d95e55bad150d66f446bc3404488e460c"
 dependencies = [
  "dusk-bytes",
  "dusk-plonk",
@@ -3310,7 +3321,7 @@ dependencies = [
  "rand 0.8.5",
  "rw-stream-sink",
  "serde",
- "smallvec",
+ "smallvec 1.10.0",
  "thiserror",
  "unsigned-varint",
  "void",
@@ -3359,7 +3370,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "parking_lot 0.12.1",
- "smallvec",
+ "smallvec 1.10.0",
  "trust-dns-resolver",
 ]
 
@@ -3380,7 +3391,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.10.0",
  "thiserror",
 ]
 
@@ -3409,7 +3420,7 @@ dependencies = [
  "regex",
  "serde",
  "sha2 0.10.6",
- "smallvec",
+ "smallvec 1.10.0",
  "thiserror",
  "unsigned-varint",
  "wasm-timer",
@@ -3432,7 +3443,7 @@ dependencies = [
  "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
- "smallvec",
+ "smallvec 1.10.0",
  "thiserror",
  "void",
 ]
@@ -3485,7 +3496,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2 0.10.6",
- "smallvec",
+ "smallvec 1.10.0",
  "thiserror",
  "uint",
  "unsigned-varint",
@@ -3507,7 +3518,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.10.0",
  "socket2",
  "tokio",
  "trust-dns-proto",
@@ -3545,7 +3556,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.1",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.10.0",
  "unsigned-varint",
 ]
 
@@ -3728,7 +3739,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.10.0",
  "unsigned-varint",
 ]
 
@@ -3750,7 +3761,7 @@ dependencies = [
  "libp2p-swarm-derive",
  "log",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.10.0",
  "tokio",
  "void",
  "wasm-bindgen-futures",
@@ -4059,6 +4070,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4340,7 +4357,7 @@ dependencies = [
  "futures",
  "log",
  "pin-project",
- "smallvec",
+ "smallvec 1.10.0",
  "unsigned-varint",
 ]
 
@@ -4887,7 +4904,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec",
+ "smallvec 1.10.0",
  "winapi",
 ]
 
@@ -4900,7 +4917,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec",
+ "smallvec 1.10.0",
  "windows-sys 0.45.0",
 ]
 
@@ -6112,6 +6129,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-hex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
+dependencies = [
+ "array-init",
+ "serde",
+ "smallvec 0.6.14",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6288,6 +6316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -6702,7 +6739,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.10.0",
  "sp-core 16.0.0",
  "sp-externalities 0.17.0",
  "sp-panic-handler",
@@ -6839,7 +6876,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "smallvec",
+ "smallvec 1.10.0",
  "sp-arithmetic",
  "sp-core 16.0.0",
  "sp-debug-derive 6.0.0",
@@ -7505,7 +7542,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.10.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -7523,7 +7560,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.10.0",
  "thread_local",
  "tracing-core",
  "tracing-log",
@@ -7540,7 +7577,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "log",
  "rustc-hex",
- "smallvec",
+ "smallvec 1.10.0",
 ]
 
 [[package]]
@@ -7569,7 +7606,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.10.0",
  "socket2",
  "thiserror",
  "tinyvec",
@@ -7591,7 +7628,7 @@ dependencies = [
  "lru-cache",
  "parking_lot 0.12.1",
  "resolv-conf",
- "smallvec",
+ "smallvec 1.10.0",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 authors = ["Polygon Avail Team"]
 
@@ -8,7 +8,7 @@ authors = ["Polygon Avail Team"]
 
 [dependencies]
 kate-recovery = { version = "0.8", git="https://github.com/availproject/avail-core", tag = "da-primitives/v0.4.6" }
-avail-subxt = { path = "../avail_1/avail-subxt" }
+avail-subxt = { git = "https://github.com/availproject/avail.git", tag = "v1.6.0" }
 dusk-plonk = { git = "https://github.com/availproject/plonk.git", tag = "v0.12.0-polygon-2"  }
 url = "2.2.2"
 tokio = { version = "1.21.2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "avail-light"
 version = "1.1.3"
 edition = "2021"
-authors = ["Polygon Avail Team"]
+authors = ["Avail Team"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,8 @@ authors = ["Polygon Avail Team"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kate-recovery = { git = "https://github.com/availproject/avail-core.git", tag = "kate-recovery/v0.8.1" }
-avail-subxt = { git = "https://github.com/availproject/avail.git", tag = "v1.5.0" }
-subxt = "0.27.1"
+kate-recovery = { version = "0.8", git="https://github.com/availproject/avail-core", tag = "da-primitives/v0.4.6" }
+avail-subxt = { path = "../avail_1/avail-subxt" }
 dusk-plonk = { git = "https://github.com/availproject/plonk.git", tag = "v0.12.0-polygon-2"  }
 url = "2.2.2"
 tokio = { version = "1.21.2", features = ["full"] }

--- a/src/app_client.rs
+++ b/src/app_client.rs
@@ -14,7 +14,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
-use avail_subxt::AvailConfig;
+use avail_subxt::{avail, utils::H256};
 use codec::Encode;
 use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
 use kate_recovery::{
@@ -30,7 +30,6 @@ use std::{
 	collections::{HashMap, HashSet},
 	sync::Arc,
 };
-use subxt::{utils::H256, OnlineClient};
 use tokio::sync::mpsc::Receiver;
 use tracing::{debug, error, info, instrument};
 
@@ -75,7 +74,7 @@ trait AppClient {
 struct AppClientImpl {
 	db: Arc<DB>,
 	network_client: Client,
-	rpc_client: OnlineClient<AvailConfig>,
+	rpc_client: avail::Client,
 }
 
 #[async_trait]
@@ -410,7 +409,7 @@ pub async fn run(
 	cfg: AppClientConfig,
 	db: Arc<DB>,
 	network_client: Client,
-	rpc_client: OnlineClient<AvailConfig>,
+	rpc_client: avail::Client,
 	app_id: u32,
 	mut block_receive: Receiver<BlockVerified>,
 	pp: PublicParameters,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,11 +43,16 @@ mod telemetry;
 mod types;
 mod utils;
 
+// The file `built.rs` was placed there by cargo and `build.rs`
+mod built_info {
+	include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
 #[derive(StructOpt, Debug)]
 #[structopt(
 	name = "avail-light",
-	about = "Light Client for Polygon Avail Blockchain",
-	author = "Polygon Avail Team",
+	about = "Light Client for Avail Blockchain",
+	author = "Avail Team",
 	version = "0.1.0"
 )]
 struct CliOpts {
@@ -243,7 +248,7 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 	let last_full_node_ws = data::get_last_full_node_ws_from_db(db.clone())?;
 
 	let version = rpc::Version {
-		version: "1.5.0".to_string(),
+		version: "1.6.0".to_string(),
 		spec_version: 9,
 		spec_name: "data-avail".to_string(),
 	};

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,11 +43,6 @@ mod telemetry;
 mod types;
 mod utils;
 
-// The file `built.rs` was placed there by cargo and `build.rs`
-mod built_info {
-	include!(concat!(env!("OUT_DIR"), "/built.rs"));
-}
-
 #[derive(StructOpt, Debug)]
 #[structopt(
 	name = "avail-light",

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -331,6 +331,7 @@ impl Client {
 	}
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum Command {
 	StartListening {

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -331,7 +331,6 @@ impl Client {
 	}
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum Command {
 	StartListening {

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -1,19 +1,18 @@
 use std::time::Instant;
 
 use anyhow::{anyhow, Context, Result};
-use avail_subxt::{primitives::Header, AvailConfig};
-use subxt::OnlineClient;
+use avail_subxt::{avail, primitives::Header};
 use tokio::sync::mpsc::Sender;
 use tokio_stream::StreamExt;
 use tracing::{error, info};
 
 pub async fn finalized_headers(
-	rpc_client: OnlineClient<AvailConfig>,
+	rpc_client: avail::Client,
 	message_tx: Sender<(Header, Instant)>,
 	error_sender: Sender<anyhow::Error>,
 ) {
 	async fn subscribe_and_process(
-		rpc_client: OnlineClient<AvailConfig>,
+		rpc_client: avail::Client,
 		message_tx: Sender<(Header, Instant)>,
 	) -> Result<()> {
 		let mut new_heads_sub = rpc_client.blocks().subscribe_finalized().await?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,44 @@
+use avail_subxt::{
+	api::runtime_types::da_primitives::{
+		asdr::data_lookup::DataLookup,
+		header::extension::HeaderExtension,
+		header::extension::{v1, v2},
+	},
+	utils::H256,
+};
 use kate_recovery::{
 	data::Cell,
 	matrix::{Dimensions, Position},
 };
+
+/// Extract fields from extension header
+pub(crate) fn extract_kate(extension: &HeaderExtension) -> (u16, u16, H256, Vec<u8>) {
+	match &extension {
+		HeaderExtension::V1(v1::HeaderExtension {
+			commitment: kate, ..
+		}) => (
+			kate.rows,
+			kate.cols,
+			kate.data_root,
+			kate.commitment.clone(),
+		),
+		HeaderExtension::V2(v2::HeaderExtension {
+			commitment: kate, ..
+		}) => (
+			kate.rows,
+			kate.cols,
+			kate.data_root.unwrap_or_default(),
+			kate.commitment.clone(),
+		),
+	}
+}
+
+pub(crate) fn extract_app_lookup(extension: &HeaderExtension) -> &DataLookup {
+	match &extension {
+		HeaderExtension::V1(v1::HeaderExtension { app_lookup, .. }) => app_lookup,
+		HeaderExtension::V2(v2::HeaderExtension { app_lookup, .. }) => app_lookup,
+	}
+}
 
 // TODO: Remove unused functions if not needed after next iteration
 


### PR DESCRIPTION
- Use the new `avail-subxt` available on `miguel/new_chainspec` node repo.
- Remove `subxt` dependency, because needed symbols are now re-exported in `avail-subxt`