### PR TITLE
Fat client memory handling optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "threadpool",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7220,6 +7221,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.3+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a678df20055b43e57ef8cddde41cdfda9a3c1a060b67f4c5836dfb1d78543ba8"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ mockall = "0.11.3"
 async-trait = "0.1.66"
 hex-literal = "0.4.0"
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"
+
 [dev-dependencies]
 proptest = "1.0.0"
 test-case = "1.2.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,13 @@ mod telemetry;
 mod types;
 mod utils;
 
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 #[derive(StructOpt, Debug)]
 #[structopt(
 	name = "avail-light",

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -60,6 +60,7 @@ pub fn init(
 	dht_parallelization_limit: usize,
 	ttl: u64,
 	put_batch_size: usize,
+	kad_remove_local_record: bool,
 ) -> Result<(Client, EventLoop)> {
 	// Create a public/private key pair, either based on a seed or random
 	let id_keys = match cfg.libp2p_secret_key {
@@ -223,7 +224,7 @@ pub fn init(
 			ttl,
 			put_batch_size,
 		),
-		EventLoop::new(swarm, command_receiver, metrics, cfg.relays),
+		EventLoop::new(swarm, command_receiver, metrics, cfg.relays, kad_remove_local_record),
 	))
 }
 


### PR DESCRIPTION
- replaced standard `glibc` allocator with `jemalloc` for more aggressive small heap chunks reclaim
- introduced instant local record deletion in fat clients, in order to reduce the memory footprint; this feature is hidden behind a flag