### PR TITLE
Replace structopt with clap.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "avail-light"
-version = "1.1.3"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -606,6 +606,7 @@ dependencies = [
  "avail-subxt",
  "base64 0.21.0",
  "chrono",
+ "clap 4.3.0",
  "confy",
  "dusk-plonk",
  "ed25519-dalek",
@@ -634,7 +635,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core 6.0.0",
- "structopt",
  "tempdir",
  "test-case",
  "thiserror",
@@ -1112,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1f23fa97e1d1641371b51f35535cb26959b8e27ab50d167a8b996b5bada819"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1123,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc5d93c358224b4d6867ef1356d740de2303e9892edc06c5340daeccd96bab"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -1148,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "codespan-reporting"
@@ -3592,7 +3592,7 @@ checksum = "f542bd9566c2c6b4a16dba22372ae767c97b210b84127db35997cf836706cf1c"
 dependencies = [
  "anyhow",
  "async-std",
- "clap 4.2.5",
+ "clap 4.3.0",
  "env_logger",
  "futures",
  "instant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light"
-version = "1.1.3"
+version = "1.4.1"
 edition = "2021"
 authors = ["Avail Team"]
 
@@ -33,7 +33,6 @@ ed25519-dalek = "1.0.1"
 async-std = { version = "1.12.0", features = ["attributes"] }
 confy = "0.4.0"
 num_cpus = "1.13.0"
-structopt = "0.3.25"
 rocksdb = { version = "0.17.0", features = ["snappy", "multi-threaded-cf"] }
 threadpool = "1.8.1"
 sp-core = "6.0.0"
@@ -44,7 +43,7 @@ warp = "0.3.2"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.15", features = ["json"] }
 prometheus-client = "0.19.0"
-
+clap = "4.3.0"
 openssl = { version = "0.10", features = ["vendored"] }
 void = "1.0.2"
 itertools = "0.10.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,12 +10,12 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use async_std::stream::StreamExt;
 use avail_subxt::primitives::Header;
+use clap::Parser;
 use consts::STATE_CF;
 use libp2p::{metrics::Metrics as LibP2PMetrics, multiaddr::Protocol, Multiaddr, PeerId};
 use prometheus_client::registry::Registry;
 use rand::{thread_rng, Rng};
 use rocksdb::{ColumnFamilyDescriptor, Options, DB};
-use structopt::StructOpt;
 use tokio::sync::mpsc::{channel, Sender};
 use tracing::{error, info, metadata::ParseLevelError, trace, warn, Level};
 use tracing_subscriber::{
@@ -43,20 +43,12 @@ mod telemetry;
 mod types;
 mod utils;
 
-#[derive(StructOpt, Debug)]
-#[structopt(
-	name = "avail-light",
-	about = "Light Client for Avail Blockchain",
-	author = "Avail Team",
-	version = "0.1.0"
-)]
-struct CliOpts {
-	#[structopt(
-		short = "c",
-		long = "config",
-		default_value = "config.yaml",
-		help = "yaml configuration file"
-	)]
+/// Light Client for Avail Blockchain
+#[derive(Parser)]
+#[command(version)]
+struct Cli {
+	/// Path to the yaml configuration file
+	#[arg(short, long, value_name = "FILE", default_value_t = String::from("config.yaml"))]
 	config: String,
 }
 
@@ -111,10 +103,10 @@ fn parse_log_level(log_level: &str, default: Level) -> (Level, Option<ParseLevel
 }
 
 async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
-	let opts = CliOpts::from_args();
+	let cli = Cli::parse();
+	let config_path = &cli.config;
 
-	let config_path = &opts.config;
-	let cfg: RuntimeConfig = confy::load_path(config_path)
+	let cfg: RuntimeConfig = confy::load_path(&config_path)
 		.context(format!("Failed to load configuration from {config_path}"))?;
 
 	info!("Using config: {cfg:?}");


### PR DESCRIPTION
This PR replaces `structopt` dependency with more up to date `clap` dependency, and fixes issue with different package and runtime versions. Version displayed by running `avail-light --version` command is the same one from `Cargo.toml` file. Previously, command was returning version from `main.rs` file.

Before replacing dependency `avail-light -h` result was:
```
avail-light 0.1.0
Avail Team
Light Client for Avail Blockchain

USAGE:
    avail-light-linux-amd64 [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -c, --config <config>    yaml configuration file [default: config.yaml]
```

After replace, result is:
```
Light Client for Avail Blockchain

Usage: avail-light [OPTIONS]

Options:
  -c, --config <FILE>  Path to the yaml configuration file [default: config.yaml]
  -h, --help           Print help
  -V, --version        Print version
```

Command `avail-light --version` returns the same as before, but with version specified in `Cargo.toml` file:

```
avail-light 1.4.1
```