### PR TITLE
Implement connection retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "async-task"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +487,7 @@ version = "1.6.0"
 dependencies = [
  "anyhow",
  "async-std",
+ "async-stream",
  "async-trait",
  "avail-core",
  "avail-subxt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
  "async-trait",
  "avail-core",
  "avail-subxt",
+ "backoff",
  "base64 0.21.2",
  "chrono",
  "clap 4.3.23",
@@ -578,6 +579,20 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.10",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ bench = false
 
 [dependencies]
 # TODO: Remove direct dependency after relevant traits are implemented in avail-subxt
-subxt = "*"
+# Also remove once error will be reexported in avail-subxt
+subxt = "0.29"
 
 # Internal deps
 avail-core = { version = "0.5", git = "https://github.com/availproject/avail-core", tag = "avail-core/v0.5.0" }
@@ -31,6 +32,7 @@ anyhow = "1.0.41"
 # 3rd-party
 async-std = { version = "1.12.0", features = ["attributes"] }
 async-trait = "0.1.66"
+backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.21.0"
 chrono = "0.4.19"
 clap = { version = "4.3.23", features = ["derive", "cargo"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ kate-recovery = { version = "0.9", git = "https://github.com/availproject/avail-
 anyhow = "1.0.41"
 # 3rd-party
 async-std = { version = "1.12.0", features = ["attributes"] }
+async-stream = "0.3"
 async-trait = "0.1.66"
 backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.21.0"

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -12,11 +12,10 @@
 use crate::api::v2;
 use crate::{
 	api::v1,
-	rpc::Node,
+	rpc::{Node, RpcClient},
 	types::{RuntimeConfig, State},
 };
 use anyhow::Context;
-use avail_subxt::avail;
 use rand::{thread_rng, Rng};
 use rocksdb::DB;
 use std::{
@@ -34,7 +33,7 @@ pub struct Server {
 	pub version: String,
 	pub network_version: String,
 	pub node: Node,
-	pub node_client: avail::Client,
+	pub rpc: RpcClient,
 }
 
 impl Server {
@@ -59,7 +58,7 @@ impl Server {
 			self.node,
 			self.state.clone(),
 			self.cfg,
-			self.node_client.clone(),
+			self.rpc.clone(),
 		);
 
 		let cors = warp::cors()

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -12,7 +12,7 @@
 use crate::api::v2;
 use crate::{
 	api::v1,
-	rpc::{Node, RpcClient},
+	rpc::RpcClient,
 	types::{RuntimeConfig, State},
 };
 use anyhow::Context;
@@ -32,7 +32,6 @@ pub struct Server {
 	pub state: Arc<Mutex<State>>,
 	pub version: String,
 	pub network_version: String,
-	pub node: Node,
 	pub rpc: RpcClient,
 }
 
@@ -55,10 +54,10 @@ impl Server {
 		let v2_api = v2::routes(
 			self.version.clone(),
 			self.network_version.clone(),
-			self.node,
+			self.rpc.clone(),
 			self.state.clone(),
 			self.cfg,
-			self.rpc.clone(),
+			self.rpc,
 		);
 
 		let cors = warp::cors()

--- a/src/api/v2/transactions.rs
+++ b/src/api/v2/transactions.rs
@@ -1,28 +1,14 @@
-use crate::rpc::RpcClient;
-use crate::types::AvailSecretKey;
+use crate::rpc::{AvailSigner, RpcClient};
 
 use super::types::{SubmitResponse, Transaction};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
-use avail_subxt::{api, primitives::AvailExtrinsicParams, AvailConfig};
-use subxt::{
-	ext::sp_core::sr25519::Pair,
-	tx::{PairSigner, SubmittableExtrinsic},
-};
+use avail_subxt::{api, primitives::AvailExtrinsicParams};
 
 #[async_trait]
 pub trait Submit {
 	async fn submit(&self, transaction: Transaction) -> Result<SubmitResponse>;
 	fn has_signer(&self) -> bool;
-}
-
-// TODO: Replace this with avail::PairSigner after implementing required traits in avail-subxt
-pub type AvailSigner = PairSigner<AvailConfig, Pair>;
-
-impl From<AvailSecretKey> for AvailSigner {
-	fn from(value: AvailSecretKey) -> Self {
-		AvailSigner::new(value.0)
-	}
 }
 
 #[derive(Clone)]
@@ -35,44 +21,33 @@ pub struct Submitter {
 #[async_trait]
 impl Submit for Submitter {
 	async fn submit(&self, transaction: Transaction) -> Result<SubmitResponse> {
-		let tx_progress: subxt::tx::TxProgress<
-			avail_subxt::AvailConfig,
-			subxt::client::OnlineClient<avail_subxt::AvailConfig>,
-		> = match transaction {
+		match transaction {
 			Transaction::Data(data) => {
 				let Some(pair_signer) = self.pair_signer.as_ref() else {
 					return Err(anyhow!("Pair signer is not configured"));
 				};
 				let extrinsic = api::tx().data_availability().submit_data(data.into());
 				let params = AvailExtrinsicParams::new_with_app_id(self.app_id.into());
-				todo!(
-					r#"
-					self.node_client
-						.tx()
-						.sign_and_submit_then_watch(&extrinsic, pair_signer, params)
-						.await?
-				"#
-				)
+				self.rpc
+					.ext_sign_and_submit_then_wait_for_finalized_success(
+						&extrinsic,
+						pair_signer,
+						params,
+					)
+					.await
 			},
 			Transaction::Extrinsic(extrinsic) => {
-				todo!(
-					r#"
-					SubmittableExtrinsic::from_bytes(self.node_client.clone(), extrinsic.into())
-						.submit_and_watch()
-						.await?
-				"#
-				)
+				self.rpc
+					.ext_raw_submit_then_wait_for_finalized_success(extrinsic.into())
+					.await
 			},
-		};
-		tx_progress
-			.wait_for_finalized_success()
-			.await
-			.map(|event| SubmitResponse {
-				block_hash: event.block_hash(),
-				hash: event.extrinsic_hash(),
-				index: event.extrinsic_index(),
-			})
-			.context("Cannot sign and submit transaction")
+		}
+		.map(|event| SubmitResponse {
+			block_hash: event.block_hash(),
+			hash: event.extrinsic_hash(),
+			index: event.extrinsic_index(),
+		})
+		.context("Cannot sign and submit transaction")
 	}
 
 	fn has_signer(&self) -> bool {

--- a/src/api/v2/transactions.rs
+++ b/src/api/v2/transactions.rs
@@ -26,7 +26,7 @@ impl From<AvailSecretKey> for AvailSigner {
 
 #[derive(Clone)]
 pub struct Submitter {
-	pub node_client: avail::Client,
+	pub node_client: RpcClient,
 	pub app_id: u32,
 	pub pair_signer: Option<AvailSigner>,
 }

--- a/src/api/v2/transactions.rs
+++ b/src/api/v2/transactions.rs
@@ -1,9 +1,10 @@
+use crate::rpc::RpcClient;
 use crate::types::AvailSecretKey;
 
 use super::types::{SubmitResponse, Transaction};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
-use avail_subxt::{api, avail, primitives::AvailExtrinsicParams, AvailConfig};
+use avail_subxt::{api, primitives::AvailExtrinsicParams, AvailConfig};
 use subxt::{
 	ext::sp_core::sr25519::Pair,
 	tx::{PairSigner, SubmittableExtrinsic},
@@ -26,7 +27,7 @@ impl From<AvailSecretKey> for AvailSigner {
 
 #[derive(Clone)]
 pub struct Submitter {
-	pub node_client: RpcClient,
+	pub rpc: RpcClient,
 	pub app_id: u32,
 	pub pair_signer: Option<AvailSigner>,
 }
@@ -34,22 +35,33 @@ pub struct Submitter {
 #[async_trait]
 impl Submit for Submitter {
 	async fn submit(&self, transaction: Transaction) -> Result<SubmitResponse> {
-		let tx_progress = match transaction {
+		let tx_progress: subxt::tx::TxProgress<
+			avail_subxt::AvailConfig,
+			subxt::client::OnlineClient<avail_subxt::AvailConfig>,
+		> = match transaction {
 			Transaction::Data(data) => {
 				let Some(pair_signer) = self.pair_signer.as_ref() else {
 					return Err(anyhow!("Pair signer is not configured"));
 				};
 				let extrinsic = api::tx().data_availability().submit_data(data.into());
 				let params = AvailExtrinsicParams::new_with_app_id(self.app_id.into());
-				self.node_client
-					.tx()
-					.sign_and_submit_then_watch(&extrinsic, pair_signer, params)
-					.await?
+				todo!(
+					r#"
+					self.node_client
+						.tx()
+						.sign_and_submit_then_watch(&extrinsic, pair_signer, params)
+						.await?
+				"#
+				)
 			},
 			Transaction::Extrinsic(extrinsic) => {
-				SubmittableExtrinsic::from_bytes(self.node_client.clone(), extrinsic.into())
-					.submit_and_watch()
-					.await?
+				todo!(
+					r#"
+					SubmittableExtrinsic::from_bytes(self.node_client.clone(), extrinsic.into())
+						.submit_and_watch()
+						.await?
+				"#
+				)
 			},
 		};
 		tx_progress

--- a/src/api/v2/ws.rs
+++ b/src/api/v2/ws.rs
@@ -1,4 +1,5 @@
 use super::types::{Clients, Request, RequestType, Response, ResponseTopic, Status, Version};
+use super::NodeGetter;
 use crate::{
 	api::v2::types::Error,
 	rpc::Node,
@@ -19,7 +20,7 @@ pub async fn connect(
 	clients: Clients,
 	version: Version,
 	config: RuntimeConfig,
-	node: Node,
+	node_getter: impl NodeGetter,
 	state: Arc<Mutex<State>>,
 ) {
 	let (web_socket_sender, mut web_socket_receiver) = web_socket.split();
@@ -50,7 +51,7 @@ pub async fn connect(
 							sender.clone(),
 							&version,
 							&config,
-							&node,
+							&node_getter.node().await,
 							state.clone(),
 						) {
 							error!("Error handling web socket message: {error}");

--- a/src/bin/api_compat_test.rs
+++ b/src/bin/api_compat_test.rs
@@ -14,7 +14,12 @@ async fn main() -> Result<()> {
 	let CommandArgs { url } = CommandArgs::parse();
 
 	println!("Using URL: {url}");
-	let rpc = avail_light::rpc::RpcClient::new(vec![url], EXPECTED_NETWORK_VERSION, None)
+
+	let backoff = backoff::ExponentialBackoffBuilder::new()
+		.with_max_elapsed_time(Some(std::time::Duration::from_secs(20)))
+		.build();
+
+	let rpc = avail_light::rpc::RpcClient::new(vec![url], EXPECTED_NETWORK_VERSION, None, backoff)
 		.await
 		.unwrap_or_else(|e| {
 			eprintln!("Couldn't establish connection with node: {e}");

--- a/src/bin/api_compat_test.rs
+++ b/src/bin/api_compat_test.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use avail_light::rpc;
+use avail_light::consts::EXPECTED_NETWORK_VERSION;
 use clap::Parser;
 use kate_recovery::matrix::Position;
 
@@ -11,10 +11,10 @@ struct CommandArgs {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-	let command_args = CommandArgs::parse();
+	let CommandArgs { url } = CommandArgs::parse();
 
-	println!("Using URL: {}", command_args.url);
-	let client = avail_subxt::build_client(command_args.url, false)
+	println!("Using URL: {url}");
+	let rpc = avail_light::rpc::RpcClient::new(vec![url], EXPECTED_NETWORK_VERSION, None)
 		.await
 		.unwrap_or_else(|e| {
 			eprintln!("Couldn't establish connection with node: {e}");
@@ -24,70 +24,70 @@ async fn main() -> Result<()> {
 	let mut correct: bool = true;
 
 	print!("Testing system version... ");
-	let res = rpc::get_system_version(&client).await;
+	let res = rpc.get_system_version().await;
 	res_helper(&res, &mut correct);
 	if let Ok(v) = res {
 		println!("Reported system version: {v}")
 	};
 
 	print!("Testing runtime version... ");
-	let res = rpc::get_runtime_version(&client).await;
+	let res = rpc.get_runtime_version().await;
 	res_helper(&res, &mut correct);
 	if let Ok(v) = res {
 		println!("Reported runtime version: {v:?}")
 	};
 
 	print!("Testing get head block header... ");
-	let res = rpc::get_chain_head_header(&client).await;
+	let res = rpc.get_chain_head_header().await;
 	let number = res.as_ref().unwrap().number; // TODO: Properly handle and skip if not working
 	res_helper(&res, &mut correct);
 
 	print!("Testing get head block hash... ");
-	let res = rpc::get_chain_head_hash(&client).await;
+	let res = rpc.get_chain_head_hash().await;
 	let hash = *res.as_ref().unwrap(); // TODO: Properly handle and skip if not working
 	res_helper(&res, &mut correct);
 
 	print!("Testing get block hash at height {number}... ");
-	let res = rpc::get_block_hash(&client, number).await;
+	let res = rpc.get_block_hash(number).await;
 	res_helper(&res, &mut correct);
 
 	print!("Testing get header at height 1... ");
-	let res = rpc::get_header_by_block_number(&client, number).await;
+	let res = rpc.get_header_by_block_number(number).await;
 	res_helper(&res, &mut correct);
 
 	print!("Testing get header by hash... ");
-	let res = rpc::get_header_by_hash(&client, hash).await;
+	let res = rpc.get_header_by_hash(hash).await;
 	res_helper(&res, &mut correct);
 
 	print!("Testing get valset at height 1... ");
-	let res = rpc::get_valset_by_block_number(&client, number).await;
+	let res = rpc.get_valset_by_block_number(number).await;
 	res_helper(&res, &mut correct);
 
 	print!("Testing get valset by hash... ");
-	let res = rpc::get_valset_by_hash(&client, hash).await;
+	let res = rpc.get_valset_by_hash(hash).await;
 	res_helper(&res, &mut correct);
 
 	print!("Testing get set_id at height 1... ");
-	let res = rpc::get_set_id_by_block_number(&client, number).await;
+	let res = rpc.get_set_id_by_block_number(number).await;
 	res_helper(&res, &mut correct);
 
 	print!("Testing get set_id by hash... ");
-	let res = rpc::get_set_id_by_hash(&client, hash).await;
+	let res = rpc.get_set_id_by_hash(hash).await;
 	res_helper(&res, &mut correct);
 
 	print!("Testing get_kate_proof for cell 0... ");
-	let res = rpc::get_kate_proof(
-		&client,
-		hash,
-		&[Position {
-			..Default::default()
-		}],
-	)
-	.await;
+	let res = rpc
+		.get_kate_proof(
+			hash,
+			&[Position {
+				..Default::default()
+			}],
+		)
+		.await;
 	res_helper(&res, &mut correct);
 
 	print!("Testing get_kate_row for row 0... ");
-	let res = rpc::get_kate_rows(&client, vec![0], hash).await;
+	let res = rpc.get_kate_rows(vec![0], hash).await;
 	res_helper(&res, &mut correct);
 
 	println!("Done");

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -259,7 +259,6 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 		version: format!("v{}", clap::crate_version!()),
 		network_version: EXPECTED_NETWORK_VERSION.to_string(),
 		rpc: rpc.clone(),
-		node: rpc.current_node().await,
 	};
 
 	tokio::task::spawn(server.run());

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -234,10 +234,15 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 	let public_params_len = hex::encode(raw_pp).len();
 	trace!("Public params ({public_params_len}): hash: {public_params_hash}");
 
+	let backoff = backoff::ExponentialBackoffBuilder::new()
+		.with_max_elapsed_time(Some(cfg.rpc_rotation_max_elapsed_time))
+		.build();
+
 	let rpc = avail_light::rpc::RpcClient::new(
 		cfg.full_node_ws.clone(),
 		EXPECTED_NETWORK_VERSION,
 		Some(db.clone()),
+		backoff,
 	)
 	.await
 	.context("Failed to create rpc client")?;

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -237,7 +237,7 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 	let rpc = avail_light::rpc::RpcClient::new(
 		cfg.full_node_ws.clone(),
 		EXPECTED_NETWORK_VERSION,
-		db.clone(),
+		Some(db.clone()),
 	)
 	.await
 	.context("Failed to create rpc client")?;

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -20,7 +20,7 @@
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use avail_subxt::{avail, primitives::Header, utils::H256};
+use avail_subxt::{primitives::Header, utils::H256};
 use codec::Encode;
 use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
 use futures::future::join_all;
@@ -69,10 +69,10 @@ pub trait LightClient {
 struct LightClientImpl {
 	db: Arc<DB>,
 	network_client: Client,
-	rpc_client: avail::Client,
+	rpc_client: rpc::RpcClient,
 }
 
-pub fn new(db: Arc<DB>, network_client: Client, rpc_client: avail::Client) -> impl LightClient {
+pub fn new(db: Arc<DB>, network_client: Client, rpc_client: rpc::RpcClient) -> impl LightClient {
 	LightClientImpl {
 		db,
 		network_client,
@@ -106,7 +106,7 @@ impl LightClient for LightClientImpl {
 			.await
 	}
 	async fn get_kate_proof(&self, hash: H256, positions: &[Position]) -> Result<Vec<Cell>> {
-		rpc::get_kate_proof(&self.rpc_client, hash, positions).await
+		self.rpc_client.get_kate_proof(hash, positions).await
 	}
 	fn store_confidence_in_db(&self, count: u32, block_number: u32) -> Result<()> {
 		store_confidence_in_db(self.db.clone(), block_number, count)

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -227,7 +227,7 @@ impl RpcClient {
 		T: serde::de::DeserializeOwned,
 	{
 		async_stream::stream! {
-			loop {
+			'outer: loop  {
 				let mut stream = match self.with_client(f).await {
 					Ok(s) => s,
 					Err(err) => {
@@ -240,7 +240,7 @@ impl RpcClient {
 					// We need to return, as stream has ended
 					let Some(result) = stream.next().await else { return };
 					// If we received error that means that we need to find a new client
-					let Ok(res) = result else { break };
+					let Ok(res) = result else { continue 'outer };
 					yield Ok(res);
 				}
 			}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -116,17 +116,10 @@ impl RpcClient {
 	}
 
 	pub async fn new(
-		mut nodes: Vec<String>,
+		nodes: Vec<String>,
 		expected_version: ExpectedVersion<'static>,
 		db: Option<Arc<DB>>,
 	) -> Result<Self> {
-		let last_full_node = db
-			.as_ref()
-			.map(Arc::clone)
-			.map(crate::data::get_last_full_node_ws_from_db)
-			.transpose()?
-			.flatten();
-		Self::shuffle_full_nodes(&mut nodes, last_full_node.as_ref());
 		let expected_genesis_hash = if let Some(db) = &db {
 			crate::data::get_genesis_hash(db.clone())?
 		} else {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -119,6 +119,7 @@ impl RpcClient {
 		nodes: Vec<String>,
 		expected_version: ExpectedVersion<'static>,
 		db: Option<Arc<DB>>,
+		backoff: backoff::ExponentialBackoff,
 	) -> Result<Self> {
 		let expected_genesis_hash = if let Some(db) = &db {
 			crate::data::get_genesis_hash(db.clone())?
@@ -138,9 +139,6 @@ impl RpcClient {
 			}
 		}
 
-		let backoff = backoff::ExponentialBackoffBuilder::new()
-			.with_max_elapsed_time(Some(std::time::Duration::from_secs(20)))
-			.build();
 		Ok(Self {
 			client: Arc::new(RwLock::new((client, node))),
 			nodes,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -136,7 +136,7 @@ impl RpcClient {
 		self.client.read().await.1.clone()
 	}
 
-	async fn with_client<F, Fut, T>(&self, mut f: F) -> Result<T>
+	pub async fn with_client<F, Fut, T>(&self, mut f: F) -> Result<T>
 	where
 		F: FnMut(avail::Client) -> Fut + Copy,
 		Fut: std::future::Future<Output = Result<T, subxt::error::Error>>,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -224,7 +224,12 @@ impl RpcClient {
 						return;
 					}
 				};
-				while let Some(Ok(res)) = stream.next().await {
+
+				loop {
+					// We need to return, as stream has ended
+					let Some(result) = stream.next().await else { return };
+					// If we received error that means that we need to find a new client
+					let Ok(res) = result else { break };
 					yield Ok(res);
 				}
 			}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -123,18 +123,10 @@ impl RpcClient {
 			.context("Failed to connect to a working node")
 	}
 
-	/// Shuffles full nodes to randomize access,
-	/// and pushes last full node to the end of a list
-	/// so we can try it if connection to other node fails
+	/// Shuffles full nodes to randomize access, removing last full node
 	fn shuffle_full_nodes(full_nodes: &mut Vec<String>, last_full_node: Option<&String>) {
-		let old_len = full_nodes.len();
 		full_nodes.retain(|node| Some(node) != last_full_node);
 		full_nodes.shuffle(&mut thread_rng());
-
-		// Pushing last full node to the end of a list, if it's only one left to try
-		if let (Some(node), true) = (last_full_node, old_len != full_nodes.len()) {
-			full_nodes.push(node.clone());
-		}
 	}
 
 	pub async fn new(
@@ -719,7 +711,6 @@ mod tests {
 
 			let mut shuffled = full_nodes.clone();
 			RpcClient::shuffle_full_nodes(&mut shuffled, last_full_node.as_ref());
-			prop_assert_eq!(shuffled.pop(), last_full_node);
 
 			// Assuming case when last full node occuring more than once in full nodes list
 			prop_assert!(shuffled.len() == full_nodes.len() - last_full_node_count);

--- a/src/types.rs
+++ b/src/types.rs
@@ -233,6 +233,8 @@ pub struct RuntimeConfig {
 	pub ot_collector_endpoint: String,
 	/// Disables fetching of cells from RPC, set to true if client expects cells to be available in DHT (default: false).
 	pub disable_rpc: bool,
+	/// Timeout during which light client tries to connect to full nodes. (default: 60s).
+	pub rpc_rotation_max_elapsed_time: Duration,
 	/// Disables proof verification in general, if set to true, otherwise proof verification is performed. (default: false).
 	pub disable_proof_verification: bool,
 	/// Maximum number of parallel tasks spawned for GET and PUT operations on DHT (default: 20).
@@ -530,6 +532,7 @@ impl Default for RuntimeConfig {
 			log_format_json: false,
 			ot_collector_endpoint: "http://otelcollector.avail.tools:4317".to_string(),
 			disable_rpc: false,
+			rpc_rotation_max_elapsed_time: Duration::from_secs(60),
 			disable_proof_verification: false,
 			dht_parallelization_limit: 20,
 			put_batch_size: 100,


### PR DESCRIPTION
Fixes https://github.com/availproject/engineering/issues/246

This pr adds a wrapper around avail client.
- A huge chunk of code is sitting in the first commit. It fixes implements reconnect and uses it everywhere apart from sync finality module and apart from subscriptions.
- Second commit fixes api compatibility binary
- 3rd one fixes sync finality to use our new backoff api
- and the last one implements reconnection streams

~I know that callsite api looks ugly right now, but there is no way around it apart from creating wrappers for those kinds of things. If you want to, I can go through each individual call to `rpc.with_client` and remove it.~