### PR TITLE
Use rayon instead of threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,6 @@ dependencies = [
  "mockall",
  "multihash 0.14.0",
  "num",
- "num_cpus",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_api",
@@ -494,13 +493,13 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rayon",
  "rocksdb",
  "serde",
  "serde_json",
  "smallvec 1.11.0",
  "sp-core 22.0.0",
  "test-case",
- "threadpool",
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
@@ -7901,15 +7900,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,16 +42,15 @@ libp2p-quic = { version = "0.9.2-alpha", features = ["tokio"] }
 mockall = "0.11.3"
 multihash = { version = "0.14.0", default-features = false, features = ["blake3", "sha3"] }
 num = "0.4.0"
-num_cpus = "1.13.0"
 pcap = "1.1.0"
 rand = "0.8.4"
 rand_chacha = "0.3"
+rayon = "1.7"
 rocksdb = { version = "0.17.0", features = ["snappy", "multi-threaded-cf"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
 smallvec = "1.6.1"
 sp-core = { version = "*" }
-threadpool = "1.8.1"
 tokio = { version = "1.25", features = ["full"] }
 tokio-stream = "0.1.12"
 tracing = "0.1.35"

--- a/src/app_client.rs
+++ b/src/app_client.rs
@@ -264,9 +264,8 @@ async fn fetch_verified(
 		.fetch_cells_from_dht(block_number, positions)
 		.await;
 
-	let (verified, mut unverified) =
-		proof::verify(block_number, dimensions, &fetched, commitments, pp)
-			.context("Failed to verify fetched cells")?;
+	let (verified, mut unverified) = proof::verify(dimensions, &fetched, commitments, pp)
+		.context("Failed to verify fetched cells")?;
 
 	fetched.retain(|cell| verified.contains(&cell.position));
 	unfetched.append(&mut unverified);

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -211,8 +211,7 @@ pub async fn process_block(
 	}
 
 	if !cfg.disable_proof_verification {
-		let (verified, unverified) =
-			proof::verify(block_number, dimensions, &cells, &commitments, pp)?;
+		let (verified, unverified) = proof::verify(dimensions, &cells, &commitments, pp)?;
 		let count = verified.len() - unverified.len();
 		info!(
 			block_number,

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -7,40 +7,24 @@ use kate_recovery::{
 	matrix::{Dimensions, Position},
 	proof,
 };
-use std::sync::{mpsc::channel, Arc};
-use tracing::error;
+use rayon::prelude::*;
+use std::sync::Arc;
 
 /// Verifies proofs for given block, cells and commitments
 pub fn verify(
-	block_num: u32,
 	dimensions: Dimensions,
 	cells: &[Cell],
 	commitments: &[[u8; 48]],
 	public_parameters: Arc<PublicParameters>,
 ) -> Result<(Vec<Position>, Vec<Position>), proof::Error> {
-	let cpus = num_cpus::get();
-	let pool = threadpool::ThreadPool::new(cpus);
-	let (tx, rx) = channel::<(Position, Result<bool, proof::Error>)>();
-
-	for cell in cells {
-		let commitment = commitments[cell.position.row as usize];
-
-		let tx = tx.clone();
-		let cell = cell.clone();
-		let public_parameters = public_parameters.clone();
-
-		pool.execute(move || {
-			let result = proof::verify(&public_parameters, dimensions, &commitment, &cell);
-			if let Err(error) = tx.clone().send((cell.position, result)) {
-				error!(block_num, "Failed to send proof verified message: {error}");
-			}
-		});
-	}
-
-	let (verified, unverified): (Vec<_>, Vec<_>) = rx
-		.iter()
+	let (verified, unverified) = cells
+		.into_par_iter()
+		.map(|cell| {
+			let commitment = &commitments[cell.position.row as usize];
+			proof::verify(&public_parameters, dimensions, commitment, cell)
+				.map(|is_verified| (cell.position, is_verified))
+		})
 		.take(cells.len())
-		.map(|(position, result)| result.map(|is_verified| (position, is_verified)))
 		.collect::<Result<Vec<(Position, bool)>, _>>()?
 		.into_iter()
 		.partition_map(|(position, is_verified)| match is_verified {

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -212,7 +212,7 @@ async fn process_block(
 	let cells_len = cells.len();
 	info!(block_number, "Fetched {cells_len} cells for verification");
 
-	let (verified, _) = proof::verify(block_number, dimensions, &cells, &commitments, pp)?;
+	let (verified, _) = proof::verify(dimensions, &cells, &commitments, pp)?;
 
 	info!(
 		block_number,


### PR DESCRIPTION
Rayon is a data-parallelism library for Rust. It features its own runtime with [threadpool which by default bounded with number of logical cores](https://github.com/rayon-rs/rayon/blob/master/FAQ.md). It allows better API without sacrificing performance and safety.

Semantically this pr, instead of spawning threadpool for each `verify`, uses one global one from rayon. Also by using rayon we no longer need to synchronization primitives.