### PR TITLE
sync_client goes crazy if finalized head height is 0

### DIFF
--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -264,7 +264,7 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 
 	let state = Arc::new(Mutex::new(State::default()));
 	state.lock().unwrap().latest = block_header.number;
-	let sync_end_block = block_header.number - 1;
+	let sync_end_block = block_header.number.saturating_sub(1);
 
 	// Spawn tokio task which runs one http server for handling RPC
 	let server = avail_light::api::server::Server {


### PR DESCRIPTION
Fix a cornercase where if current head height is 0, then the sync end_block will be u32::MAX