### PR TITLE
Switched from main branch to tag for avail and avail-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "avail-core"
 version = "0.5.1"
-source = "git+https://github.com/availproject/avail-core?branch=main#728512e3a0a40a41c73cb56c9cd858d16dc86c70"
+source = "git+https://github.com/availproject/avail-core?tag=v1.7.0#4c3fdf4a3a7267fbd9ef68372e4e7ba94cd7fe74"
 dependencies = [
  "binary-merkle-tree",
  "derive_more",
@@ -442,13 +442,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 16.0.0",
- "sp-core 21.0.0",
- "sp-io 23.0.0",
+ "sp-arithmetic 7.0.0",
+ "sp-core 8.0.0",
+ "sp-io 8.0.0",
  "sp-runtime 24.0.0",
  "sp-runtime-interface 17.0.0",
- "sp-std 8.0.0",
- "sp-trie 22.0.0",
+ "sp-std 6.0.0",
+ "sp-trie 8.0.0",
  "static_assertions",
  "thiserror-no-std",
 ]
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "avail-subxt"
 version = "0.4.0"
-source = "git+https://github.com/availproject/avail.git?branch=main#2aefb9da3238916a7bd359dab34f8948b89127f7"
+source = "git+https://github.com/availproject/avail.git?tag=v1.7.0#ae58dcee4ad616be3db98b9c3fb6308f7ec49ed2"
 dependencies = [
  "anyhow",
  "curve25519-dalek 2.1.3",
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "kate-recovery"
 version = "0.9.1"
-source = "git+https://github.com/availproject/avail-core?branch=main#728512e3a0a40a41c73cb56c9cd858d16dc86c70"
+source = "git+https://github.com/availproject/avail-core?tag=v1.7.0#4c3fdf4a3a7267fbd9ef68372e4e7ba94cd7fe74"
 dependencies = [
  "avail-core",
  "derive_more",
@@ -2926,8 +2926,8 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
- "sp-arithmetic 16.0.0",
- "sp-std 8.0.0",
+ "sp-arithmetic 7.0.0",
+ "sp-std 6.0.0",
  "static_assertions",
  "thiserror-no-std",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ subxt = "0.29"
 
 # Internal deps
 # TODO: Change with tags
-avail-core = { version = "0.5", git = "https://github.com/availproject/avail-core", branch = "main" }
-avail-subxt = { version = "0.4", git = "https://github.com/availproject/avail.git", branch = "main" }
+avail-core = { version = "0.5", git = "https://github.com/availproject/avail-core", tag = "v1.7.0" }
+avail-subxt = { version = "0.4", git = "https://github.com/availproject/avail.git", tag = "v1.7.0" }
 dusk-plonk = { git = "https://github.com/availproject/plonk.git", tag = "v0.12.0-polygon-2" }
-kate-recovery = { version = "0.9", git = "https://github.com/availproject/avail-core", branch = "main" }
+kate-recovery = { version = "0.9", git = "https://github.com/availproject/avail-core", tag = "v1.7.0" }
 
 # Substrate
 anyhow = "1.0.41"


### PR DESCRIPTION
Moved from depending on the main branch to depending on the v1.7.0 tag for avail and avail-core.
For some reason it did changes that I didn't expected to see and I cannot explain them
![image](https://github.com/availproject/avail-light/assets/4882434/9c2b12fe-1801-4894-913f-eaa09c73c44c)
