### PR TITLE
291: LC Cleanup post Bootstrap Update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,9 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2-sys"
@@ -2080,6 +2083,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-ticker"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "instant",
+]
+
+[[package]]
 name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,6 +2407,12 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hmac"
@@ -3011,6 +3031,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-dcutr",
  "libp2p-dns",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
@@ -3092,6 +3113,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
+ "serde",
  "smallvec 1.11.0",
  "thiserror",
  "unsigned-varint",
@@ -3135,6 +3157,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-gossipsub"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d157562dba6017193e5285acf6b1054759e83540bfd79f75b69d6ce774c88da"
+dependencies = [
+ "asynchronous-codec",
+ "base64 0.21.2",
+ "byteorder",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-ticker",
+ "getrandom 0.2.10",
+ "hex_fmt",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "log",
+ "prometheus-client",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "sha2 0.10.7",
+ "smallvec 1.11.0",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
 name = "libp2p-identify"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,6 +3223,7 @@ dependencies = [
  "multihash 0.19.0",
  "quick-protobuf",
  "rand 0.8.5",
+ "serde",
  "sha2 0.10.7",
  "thiserror",
  "zeroize",
@@ -3193,6 +3249,7 @@ dependencies = [
  "log",
  "quick-protobuf",
  "rand 0.8.5",
+ "serde",
  "sha2 0.10.7",
  "smallvec 1.11.0",
  "thiserror",
@@ -3866,6 +3923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd59dcc2bbe70baabeac52cd22ae52c55eefe6c38ff11a9439f16a350a939f2"
 dependencies = [
  "core2",
+ "serde",
  "unsigned-varint",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,42 +35,16 @@ async-trait = "0.1.66"
 base64 = "0.21.0"
 chrono = "0.4.19"
 clap = { version = "4.3.23", features = ["derive", "cargo"] }
-codec = { package = "parity-scale-codec", version = "3", default-features = false, features = [
-    "derive",
-    "full",
-    "bit-vec",
-] }
+codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full", "bit-vec" ] }
 confy = "0.4.0"
 derive_more = { version = "0.99.17", features = ["from"] }
-futures = { version = "0.3.15", default-features = false, features = [
-    "std",
-    "async-await",
-] }
+futures = { version = "0.3.15", default-features = false, features = ["std", "async-await" ] }
 hex = "0.4"
 hyper = { version = "0.14.23", features = ["full", "http1"] }
 itertools = "0.10.5"
-libp2p = { version = "0.52.3", features = [
-    "kad",
-    "identify",
-    "ping",
-    "mdns",
-    "autonat",
-    "relay",
-    "dcutr",
-    "noise",
-    "yamux",
-    "dns",
-    "metrics",
-    "tokio",
-    "macros",
-    "quic",
-    "serde",
-] }
+libp2p = { version = "0.52.3", features = ["kad", "identify", "ping", "mdns", "autonat", "relay", "dcutr", "noise", "yamux", "dns", "metrics", "tokio", "macros", "quic", "serde"] }
 mockall = "0.11.3"
-multihash = { version = "0.14.0", default-features = false, features = [
-    "blake3",
-    "sha3",
-] }
+multihash = { version = "0.14.0", default-features = false, features = ["blake3", "sha3" ] }
 num = "0.4.0"
 num_cpus = "1.13.0"
 pcap = "1.1.0"
@@ -86,21 +60,13 @@ tokio = { version = "1.25", features = ["full"] }
 tokio-stream = "0.1.12"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.15", features = ["json"] }
-uuid = { version = "1.3.4", features = [
-    "v4",
-    "fast-rng",
-    "macro-diagnostics",
-    "serde",
-] }
+uuid = { version = "1.3.4", features = ["v4", "fast-rng", "macro-diagnostics", "serde" ] }
 void = "1.0.2"
 warp = "0.3.2"
 
 # OpenTelemetry
 opentelemetry = "0.20.0"
-opentelemetry-otlp = { version = "0.13.0", features = [
-    "grpc-tonic",
-    "metrics",
-] }
+opentelemetry-otlp = { version = "0.13.0", features = ["grpc-tonic", "metrics" ] }
 opentelemetry_api = { version = "0.20.0", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.20.0", features = ["metrics", "rt-tokio"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,16 +35,16 @@ async-trait = "0.1.66"
 base64 = "0.21.0"
 chrono = "0.4.19"
 clap = { version = "4.3.23", features = ["derive", "cargo"] }
-codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full", "bit-vec" ] }
+codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full", "bit-vec"] }
 confy = "0.4.0"
 derive_more = { version = "0.99.17", features = ["from"] }
-futures = { version = "0.3.15", default-features = false, features = ["std", "async-await" ] }
+futures = { version = "0.3.15", default-features = false, features = ["std", "async-await"] }
 hex = "0.4"
 hyper = { version = "0.14.23", features = ["full", "http1"] }
 itertools = "0.10.5"
 libp2p = { version = "0.52.3", features = ["kad", "identify", "ping", "mdns", "autonat", "relay", "dcutr", "noise", "yamux", "dns", "metrics", "tokio", "macros", "quic", "serde"] }
 mockall = "0.11.3"
-multihash = { version = "0.14.0", default-features = false, features = ["blake3", "sha3" ] }
+multihash = { version = "0.14.0", default-features = false, features = ["blake3", "sha3"] }
 num = "0.4.0"
 num_cpus = "1.13.0"
 pcap = "1.1.0"
@@ -60,13 +60,13 @@ tokio = { version = "1.25", features = ["full"] }
 tokio-stream = "0.1.12"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.15", features = ["json"] }
-uuid = { version = "1.3.4", features = ["v4", "fast-rng", "macro-diagnostics", "serde" ] }
+uuid = { version = "1.3.4", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
 void = "1.0.2"
 warp = "0.3.2"
 
 # OpenTelemetry
 opentelemetry = "0.20.0"
-opentelemetry-otlp = { version = "0.13.0", features = ["grpc-tonic", "metrics" ] }
+opentelemetry-otlp = { version = "0.13.0", features = ["grpc-tonic", "metrics"] }
 opentelemetry_api = { version = "0.20.0", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.20.0", features = ["metrics", "rt-tokio"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,16 +35,42 @@ async-trait = "0.1.66"
 base64 = "0.21.0"
 chrono = "0.4.19"
 clap = { version = "4.3.23", features = ["derive", "cargo"] }
-codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full", "bit-vec"] }
+codec = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+    "full",
+    "bit-vec",
+] }
 confy = "0.4.0"
 derive_more = { version = "0.99.17", features = ["from"] }
-futures = { version = "0.3.15", default-features = false, features = ["std", "async-await"] }
+futures = { version = "0.3.15", default-features = false, features = [
+    "std",
+    "async-await",
+] }
 hex = "0.4"
 hyper = { version = "0.14.23", features = ["full", "http1"] }
 itertools = "0.10.5"
-libp2p = { version = "0.52.3", features = ["kad", "identify", "ping", "mdns", "autonat", "relay", "dcutr", "noise", "yamux", "dns", "metrics", "tokio", "macros", "quic"] }
+libp2p = { version = "0.52.3", features = [
+    "kad",
+    "identify",
+    "ping",
+    "mdns",
+    "autonat",
+    "relay",
+    "dcutr",
+    "noise",
+    "yamux",
+    "dns",
+    "metrics",
+    "tokio",
+    "macros",
+    "quic",
+    "serde",
+] }
 mockall = "0.11.3"
-multihash = { version = "0.14.0", default-features = false, features = ["blake3", "sha3"] }
+multihash = { version = "0.14.0", default-features = false, features = [
+    "blake3",
+    "sha3",
+] }
 num = "0.4.0"
 num_cpus = "1.13.0"
 pcap = "1.1.0"
@@ -60,13 +86,21 @@ tokio = { version = "1.25", features = ["full"] }
 tokio-stream = "0.1.12"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.15", features = ["json"] }
-uuid = { version = "1.3.4", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
+uuid = { version = "1.3.4", features = [
+    "v4",
+    "fast-rng",
+    "macro-diagnostics",
+    "serde",
+] }
 void = "1.0.2"
 warp = "0.3.2"
 
 # OpenTelemetry
 opentelemetry = "0.20.0"
-opentelemetry-otlp = { version = "0.13.0", features = ["grpc-tonic", "metrics"] }
+opentelemetry-otlp = { version = "0.13.0", features = [
+    "grpc-tonic",
+    "metrics",
+] }
 opentelemetry_api = { version = "0.20.0", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.20.0", features = ["metrics", "rt-tokio"] }
 

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -14,6 +14,7 @@ use avail_light::{
 };
 use avail_subxt::primitives::Header;
 use clap::Parser;
+use kate_recovery::com::AppData;
 use libp2p::{multiaddr::Protocol, Multiaddr};
 use rocksdb::{ColumnFamilyDescriptor, Options, DB};
 use std::{

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -637,9 +637,18 @@ mod tests {
 		mock_client
 			.expect_shrink_kademlia_map()
 			.returning(|| Box::pin(async move { Ok(()) }));
+		mock_client.expect_get_multiaddress_and_ip().returning(|| {
+			Box::pin(async move { Ok(("multiaddress".to_string(), "ip".to_string())) })
+		});
+		mock_client
+			.expect_count_dht_entries()
+			.returning(|| Box::pin(async move { Ok(1) }));
+
 		let mut mock_metrics = telemetry::MockMetrics::new();
 		mock_metrics.expect_count().returning(|_| ());
 		mock_metrics.expect_record().returning(|_| Ok(()));
+		mock_metrics.expect_set_multiaddress().returning(|_| ());
+		mock_metrics.expect_set_ip().returning(|_| ());
 		process_block(
 			&mock_client,
 			&Arc::new(mock_metrics),
@@ -763,10 +772,18 @@ mod tests {
 		mock_client
 			.expect_shrink_kademlia_map()
 			.returning(|| Box::pin(async move { Ok(()) }));
+		mock_client.expect_get_multiaddress_and_ip().returning(|| {
+			Box::pin(async move { Ok(("multiaddress".to_string(), "ip".to_string())) })
+		});
+		mock_client
+			.expect_count_dht_entries()
+			.returning(|| Box::pin(async move { Ok(1) }));
 
 		let mut mock_metrics = telemetry::MockMetrics::new();
 		mock_metrics.expect_count().returning(|_| ());
 		mock_metrics.expect_record().returning(|_| Ok(()));
+		mock_metrics.expect_set_multiaddress().returning(|_| ());
+		mock_metrics.expect_set_ip().returning(|_| ());
 		process_block(
 			&mock_client,
 			&Arc::new(mock_metrics),

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -106,7 +106,7 @@ impl LightClient for LightClientImpl {
 	async fn get_kate_proof(&self, hash: H256, positions: &[Position]) -> Result<Vec<Cell>> {
 		rpc::get_kate_proof(&self.rpc_client, hash, positions).await
 	}
-	async fn get_multiaddress_and_ip(&self) -> Option<(String, String)> {
+	async fn get_multiaddress_and_ip(&self) -> Result<(String, String)> {
 		self.network_client.get_multiaddress_and_ip().await
 	}
 	async fn count_dht_entries(&self) -> Result<usize> {

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -60,7 +60,7 @@ pub trait LightClient {
 	async fn insert_rows_into_dht(&self, block: u32, rows: Vec<(RowIndex, Vec<u8>)>) -> f32;
 	async fn get_kate_proof(&self, hash: H256, positions: &[Position]) -> Result<Vec<Cell>>;
 	async fn shrink_kademlia_map(&self) -> Result<()>;
-	async fn get_multiaddress_and_ip(&self) -> Option<(String, String)>;
+	async fn get_multiaddress_and_ip(&self) -> Result<(String, String)>;
 	async fn count_dht_entries(&self) -> Result<usize>;
 	fn store_block_header_in_db(&self, header: &Header, block_number: u32) -> Result<()>;
 	fn store_confidence_in_db(&self, count: u32, block_number: u32) -> Result<()>;

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -60,7 +60,8 @@ pub trait LightClient {
 	async fn insert_rows_into_dht(&self, block: u32, rows: Vec<(RowIndex, Vec<u8>)>) -> f32;
 	async fn get_kate_proof(&self, hash: H256, positions: &[Position]) -> Result<Vec<Cell>>;
 	async fn shrink_kademlia_map(&self) -> Result<()>;
-	async fn network_stats(&self) -> Result<()>;
+	async fn get_multiaddress_and_ip(&self) -> Option<(String, String)>;
+	async fn count_dht_entries(&self) -> Result<usize>;
 	fn store_block_header_in_db(&self, header: &Header, block_number: u32) -> Result<()>;
 	fn store_confidence_in_db(&self, count: u32, block_number: u32) -> Result<()>;
 }
@@ -90,9 +91,6 @@ impl LightClient for LightClientImpl {
 	async fn shrink_kademlia_map(&self) -> Result<()> {
 		self.network_client.shrink_kademlia_map().await
 	}
-	async fn network_stats(&self) -> Result<()> {
-		self.network_client.network_stats().await
-	}
 	async fn insert_rows_into_dht(&self, block: u32, rows: Vec<(RowIndex, Vec<u8>)>) -> f32 {
 		self.network_client.insert_rows_into_dht(block, rows).await
 	}
@@ -107,6 +105,12 @@ impl LightClient for LightClientImpl {
 	}
 	async fn get_kate_proof(&self, hash: H256, positions: &[Position]) -> Result<Vec<Cell>> {
 		rpc::get_kate_proof(&self.rpc_client, hash, positions).await
+	}
+	async fn get_multiaddress_and_ip(&self) -> Option<(String, String)> {
+		self.network_client.get_multiaddress_and_ip().await
+	}
+	async fn count_dht_entries(&self) -> Result<usize> {
+		self.network_client.count_dht_entries().await
 	}
 	fn store_confidence_in_db(&self, count: u32, block_number: u32) -> Result<()> {
 		store_confidence_in_db(self.db.clone(), block_number, count)
@@ -126,9 +130,11 @@ pub async fn process_block(
 	header: &Header,
 	received_at: Instant,
 	state: Arc<Mutex<State>>,
-) -> Result<Option<f64>> {
-	metrics.count(MetricCounter::SessionBlock);
-	metrics.record(MetricValue::TotalBlockNumber(header.number))?;
+) -> Result<()> {
+	metrics.count(MetricCounter::SessionBlock).await;
+	metrics
+		.record(MetricValue::TotalBlockNumber(header.number))
+		.await?;
 
 	let block_number = header.number;
 	let header_hash: H256 = Encode::using_encoded(header, blake2_256).into();
@@ -174,11 +180,15 @@ pub async fn process_block(
 		"Number of cells fetched from DHT: {}",
 		cells_fetched.len()
 	);
-	metrics.record(MetricValue::DHTFetched(cells_fetched.len() as f64))?;
+	metrics
+		.record(MetricValue::DHTFetched(cells_fetched.len() as f64))
+		.await?;
 
-	metrics.record(MetricValue::DHTFetchedPercentage(
-		cells_fetched.len() as f64 / positions.len() as f64,
-	))?;
+	metrics
+		.record(MetricValue::DHTFetchedPercentage(
+			cells_fetched.len() as f64 / positions.len() as f64,
+		))
+		.await?;
 
 	let mut rpc_fetched = if cfg.disable_rpc {
 		vec![]
@@ -195,7 +205,9 @@ pub async fn process_block(
 		"Number of cells fetched from RPC: {}",
 		rpc_fetched.len()
 	);
-	metrics.record(MetricValue::NodeRPCFetched(rpc_fetched.len() as f64))?;
+	metrics
+		.record(MetricValue::NodeRPCFetched(rpc_fetched.len() as f64))
+		.await?;
 
 	let mut cells = vec![];
 	cells.extend(cells_fetched);
@@ -210,7 +222,7 @@ pub async fn process_block(
 		return Ok(None);
 	}
 
-	let mut condifence = None;
+	let mut confidence = None;
 	if !cfg.disable_proof_verification {
 		let (verified, unverified) =
 			proof::verify(block_number, dimensions, &cells, &commitments, pp)?;
@@ -235,8 +247,8 @@ pub async fn process_block(
 			"Confidence factor: {}",
 			conf
 		);
-		metrics.record(MetricValue::BlockConfidence(conf))?;
-		condifence = Some(conf);
+		metrics.record(MetricValue::BlockConfidence(conf)).await?;
+		confidence = Some(conf);
 	}
 
 	// push latest mined block's header into column family specified
@@ -315,7 +327,9 @@ pub async fn process_block(
 			"DHT PUT rows operation success rate: {dht_insert_rows_success_rate}"
 		);
 
-		metrics.record(MetricValue::DHTPutRowsSuccess(success_rate))?;
+		metrics
+			.record(MetricValue::DHTPutRowsSuccess(success_rate))
+			.await?;
 
 		info!(
 			block_number,
@@ -323,7 +337,9 @@ pub async fn process_block(
 			"{rows_len} rows inserted into DHT"
 		);
 
-		metrics.record(MetricValue::DHTPutRowsDuration(time_elapsed.as_secs_f64()))?;
+		metrics
+			.record(MetricValue::DHTPutRowsDuration(time_elapsed.as_secs_f64()))
+			.await?;
 	}
 
 	let partition_time_elapsed = begin.elapsed();
@@ -334,9 +350,11 @@ pub async fn process_block(
 		"partition_cells_fetched" = rpc_fetched_len,
 		"Partition cells received",
 	);
-	metrics.record(MetricValue::RPCCallDuration(
-		partition_time_elapsed.as_secs_f64(),
-	))?;
+	metrics
+		.record(MetricValue::RPCCallDuration(
+			partition_time_elapsed.as_secs_f64(),
+		))
+		.await?;
 
 	begin = Instant::now();
 
@@ -349,7 +367,9 @@ pub async fn process_block(
 		"DHT PUT operation success rate: {}", dht_insert_success_rate
 	);
 
-	metrics.record(MetricValue::DHTPutSuccess(dht_insert_success_rate as f64))?;
+	metrics
+		.record(MetricValue::DHTPutSuccess(dht_insert_success_rate as f64))
+		.await?;
 
 	let dht_put_time_elapsed = begin.elapsed();
 	info!(
@@ -358,23 +378,32 @@ pub async fn process_block(
 		"{rpc_fetched_len} cells inserted into DHT",
 	);
 
-	metrics.record(MetricValue::DHTPutDuration(
-		dht_put_time_elapsed.as_secs_f64(),
-	))?;
+	metrics
+		.record(MetricValue::DHTPutDuration(
+			dht_put_time_elapsed.as_secs_f64(),
+		))
+		.await?;
 
 	light_client
 		.shrink_kademlia_map()
 		.await
 		.context("Unable to perform Kademlia map shrink")?;
 
-	light_client
-		.network_stats()
-		.await
-		.context("Unable to dump network stats")?;
+	// dump what we have on the current p2p network
+	if let Some((multiaddr, ip)) = light_client.get_multiaddress_and_ip().await {
+		// set Multiaddress
+		metrics.set_multiaddress(multiaddr).await;
+		metrics.set_ip(ip).await;
+	}
+	if let Ok(counted_peers) = light_client.count_dht_entries().await {
+		metrics
+			.record(MetricValue::KadRoutingPeerNum(counted_peers))
+			.await?
+	}
 
 	metrics.record(MetricValue::HealthCheck())?;
 
-	Ok(condifence)
+	Ok(confidence)
 }
 
 pub struct Channels {
@@ -608,9 +637,6 @@ mod tests {
 		mock_client
 			.expect_shrink_kademlia_map()
 			.returning(|| Box::pin(async move { Ok(()) }));
-		mock_client
-			.expect_network_stats()
-			.returning(|| Box::pin(async move { Ok(()) }));
 		let mut mock_metrics = telemetry::MockMetrics::new();
 		mock_metrics.expect_count().returning(|_| ());
 		mock_metrics.expect_record().returning(|_| Ok(()));
@@ -737,9 +763,7 @@ mod tests {
 		mock_client
 			.expect_shrink_kademlia_map()
 			.returning(|| Box::pin(async move { Ok(()) }));
-		mock_client
-			.expect_network_stats()
-			.returning(|| Box::pin(async move { Ok(()) }));
+
 		let mut mock_metrics = telemetry::MockMetrics::new();
 		mock_metrics.expect_count().returning(|_| ());
 		mock_metrics.expect_record().returning(|_| Ok(()));

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -390,7 +390,7 @@ pub async fn process_block(
 		.context("Unable to perform Kademlia map shrink")?;
 
 	// dump what we have on the current p2p network
-	if let Some((multiaddr, ip)) = light_client.get_multiaddress_and_ip().await {
+	if let Ok((multiaddr, ip)) = light_client.get_multiaddress_and_ip().await {
 		// set Multiaddress
 		metrics.set_multiaddress(multiaddr).await;
 		metrics.set_ip(ip).await;

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -130,7 +130,7 @@ pub async fn process_block(
 	header: &Header,
 	received_at: Instant,
 	state: Arc<Mutex<State>>,
-) -> Result<()> {
+) -> Result<Option<f64>> {
 	metrics.count(MetricCounter::SessionBlock).await;
 	metrics
 		.record(MetricValue::TotalBlockNumber(header.number))
@@ -401,7 +401,7 @@ pub async fn process_block(
 			.await?
 	}
 
-	metrics.record(MetricValue::HealthCheck())?;
+	metrics.record(MetricValue::HealthCheck()).await?;
 
 	Ok(confidence)
 }

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -382,6 +382,9 @@ pub enum Command {
 	CountDHTPeers {
 		response_sender: oneshot::Sender<usize>,
 	},
+	GetCellsInDHTPerBlock {
+		response_sender: oneshot::Sender<Result<()>>,
+	},
 	GetMultiaddress {
 		response_sender: oneshot::Sender<Option<Multiaddr>>,
 	},

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use futures::future::join_all;
 use kate_recovery::{
 	config,
@@ -341,18 +341,18 @@ impl Client {
 		self.insert_into_dht(records).await
 	}
 
-	pub async fn get_multiaddress_and_ip(&self) -> Option<(String, String)> {
+	pub async fn get_multiaddress_and_ip(&self) -> Result<(String, String)> {
 		if let Ok(Some(addr)) = self.get_multiaddress().await {
 			for protocol in &addr {
 				match protocol {
-					Protocol::Ip4(ip) => return Some((addr.to_string(), ip.to_string())),
-					Protocol::Ip6(ip) => return Some((addr.to_string(), ip.to_string())),
+					Protocol::Ip4(ip) => return Ok((addr.to_string(), ip.to_string())),
+					Protocol::Ip6(ip) => return Ok((addr.to_string(), ip.to_string())),
 					_ => continue,
 				}
 			}
-			return None;
+			return Err(anyhow!("No IP Address was present in Multiaddress"));
 		}
-		None
+		Err(anyhow!("No Multiaddress was present for Local Node"))
 	}
 }
 

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -164,14 +164,6 @@ impl Client {
 			.context("Command receiver should not be dropped.")
 	}
 
-	// Dump p2p network stats in a readable manner
-	pub async fn network_stats(&self) -> Result<()> {
-		self.sender
-			.send(Command::NetworkObservabilityDump)
-			.await
-			.context("Command receiver should not be dropped.")
-	}
-
 	// Since callers ignores DHT errors, debug logs are used to observe DHT behavior.
 	// Return type assumes that cell is not found in case when error is present.
 	async fn fetch_cell_from_dht(&self, block_number: u32, position: Position) -> Option<Cell> {
@@ -352,8 +344,13 @@ pub enum Command {
 	PutKadRecordBatch {
 		records: Arc<[Record]>,
 		quorum: Quorum,
-		sender: oneshot::Sender<NumSuccPut>,
+		response_sender: oneshot::Sender<NumSuccPut>,
+	},
+	CountDHTPeers {
+		response_sender: oneshot::Sender<usize>,
+	},
+	GetMultiaddress {
+		response_sender: oneshot::Sender<Option<Multiaddr>>,
 	},
 	ReduceKademliaMapSize,
-	NetworkObservabilityDump,
 }

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -1,8 +1,3 @@
-use std::{
-	sync::Arc,
-	time::{Duration, Instant},
-};
-
 use anyhow::{Context, Result};
 use futures::future::join_all;
 use kate_recovery::{
@@ -14,11 +9,12 @@ use libp2p::{
 	kad::{record::Key, PeerRecord, Quorum, Record},
 	Multiaddr, PeerId,
 };
+use std::{
+	sync::Arc,
+	time::{Duration, Instant},
+};
 use tokio::sync::{mpsc, oneshot};
-use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, trace};
-
-use super::Event;
 
 #[derive(Clone)]
 pub struct Client {
@@ -106,19 +102,6 @@ impl Client {
 			.await
 			.context("Command receiver should not be dropped.")?;
 		receiver.await.context("Sender not to be dropped.")?
-	}
-
-	// Events stream function creates a new stream of
-	// network events and sends a command to the Event loop
-	// with a required sender for event output
-	pub async fn events_stream(&self) -> ReceiverStream<Event> {
-		let (sender, receiver) = mpsc::channel(1000);
-		self.sender
-			.send(Command::Stream { sender })
-			.await
-			.expect("Command receiver should not be dropped.");
-
-		ReceiverStream::new(receiver)
 	}
 
 	pub async fn bootstrap(&self, nodes: Vec<(PeerId, Multiaddr)>) -> Result<()> {

--- a/src/network/event_loop.rs
+++ b/src/network/event_loop.rs
@@ -553,9 +553,16 @@ impl EventLoop {
 					.store_mut()
 					.shrink_hashmap();
 			},
-			Command::NetworkObservabilityDump => {
-				self.dump_routing_table_stats().await;
-				self.dump_hash_map_block_stats();
+			Command::CountDHTPeers { response_sender } => {
+				let mut total_peers: usize = 0;
+				for bucket in self.swarm.behaviour_mut().kademlia.kbuckets() {
+					total_peers += bucket.num_entries();
+				}
+				_ = response_sender.send(total_peers);
+			},
+			Command::GetMultiaddress { response_sender } => {
+				let last_address = self.swarm.external_addresses().last();
+				_ = response_sender.send(last_address.cloned());
 			},
 		}
 	}

--- a/src/network/event_loop.rs
+++ b/src/network/event_loop.rs
@@ -484,7 +484,10 @@ impl EventLoop {
 
 	async fn handle_command(&mut self, command: Command) {
 		match command {
-			Command::StartListening { addr, sender } => {
+			Command::StartListening {
+				addr,
+				response_sender: sender,
+			} => {
 				_ = match self.swarm.listen_on(addr) {
 					Ok(_) => sender.send(Ok(())),
 					Err(e) => sender.send(Err(e.into())),
@@ -493,7 +496,7 @@ impl EventLoop {
 			Command::AddAddress {
 				peer_id,
 				peer_addr,
-				sender,
+				response_sender: sender,
 			} => {
 				self.swarm
 					.behaviour_mut()
@@ -502,10 +505,9 @@ impl EventLoop {
 
 				self.pending_kad_routing.insert(peer_id, sender);
 			},
-			Command::Stream { sender } => {
-				self.output_senders.push(sender);
-			},
-			Command::Bootstrap { sender } => {
+			Command::Bootstrap {
+				response_sender: sender,
+			} => {
 				let query_id = self
 					.swarm
 					.behaviour_mut()
@@ -516,7 +518,10 @@ impl EventLoop {
 				self.pending_kad_queries
 					.insert(query_id, QueryChannel::Bootstrap(sender));
 			},
-			Command::GetKadRecord { key, sender } => {
+			Command::GetKadRecord {
+				key,
+				response_sender: sender,
+			} => {
 				let query_id = self.swarm.behaviour_mut().kademlia.get_record(key);
 
 				self.pending_kad_queries
@@ -525,7 +530,7 @@ impl EventLoop {
 			Command::PutKadRecordBatch {
 				records,
 				quorum,
-				sender,
+				response_sender: sender,
 			} => {
 				let mut ids: HashMap<QueryId, QueryState> = Default::default();
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -3,7 +3,7 @@ use event_loop::EventLoop;
 use futures::future::Either;
 use libp2p::{
 	autonat::{self, Behaviour as AutoNat},
-	core::{muxing::StreamMuxerBox, transport::OrTransport, upgrade::Version, ConnectedPoint},
+	core::{muxing::StreamMuxerBox, transport::OrTransport, upgrade::Version},
 	dcutr::Behaviour as Dcutr,
 	dns::TokioDnsConfig,
 	identify::{self, Behaviour as Identify},
@@ -34,15 +34,6 @@ use crate::{
 	telemetry::NetworkDumpEvent,
 	types::{LibP2PConfig, SecretKey},
 };
-
-// Event enum encodes all used network event variants
-#[derive(Debug, Clone)]
-pub enum Event {
-	ConnectionEstablished {
-		peer_id: PeerId,
-		endpoint: ConnectedPoint,
-	},
-}
 
 #[derive(NetworkBehaviour)]
 #[behaviour(event_process = false)]

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use mockall::automock;
 
 pub mod otlp;
@@ -33,7 +34,10 @@ pub enum MetricValue {
 }
 
 #[automock]
+#[async_trait]
 pub trait Metrics {
-	fn count(&self, counter: MetricCounter);
-	fn record(&self, value: MetricValue) -> Result<()>;
+	async fn count(&self, counter: MetricCounter);
+	async fn record(&self, value: MetricValue) -> Result<()>;
+	async fn set_multiaddress(&self, multiaddr: String);
+	async fn set_ip(&self, ip: String);
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -8,12 +8,6 @@ pub enum MetricCounter {
 	SessionBlock,
 }
 
-pub struct NetworkDumpEvent {
-	pub routing_table_num_of_peers: usize,
-	pub current_multiaddress: String,
-	pub current_ip: String,
-}
-
 pub enum MetricValue {
 	TotalBlockNumber(u32),
 	DHTFetched(f64),
@@ -25,7 +19,7 @@ pub enum MetricValue {
 	DHTPutSuccess(f64),
 	DHTPutRowsDuration(f64),
 	DHTPutRowsSuccess(f64),
-	KadRoutingTablePeerNum(u32),
+	KadRoutingPeerNum(usize),
 	HealthCheck(),
 	#[cfg(feature = "crawl")]
 	CrawlCellsSuccessRate(f64),

--- a/src/telemetry/otlp.rs
+++ b/src/telemetry/otlp.rs
@@ -111,7 +111,7 @@ impl super::Metrics for Metrics {
 					.await?;
 			},
 			super::MetricValue::HealthCheck() => {
-				self.record_u64("up", 1)?;
+				self.record_u64("up", 1).await?;
 			},
 			#[cfg(feature = "crawl")]
 			super::MetricValue::CrawlCellsSuccessRate(number) => {

--- a/src/telemetry/otlp.rs
+++ b/src/telemetry/otlp.rs
@@ -115,11 +115,11 @@ impl super::Metrics for Metrics {
 			},
 			#[cfg(feature = "crawl")]
 			super::MetricValue::CrawlCellsSuccessRate(number) => {
-				self.record_f64("crawl_cells_success_rate", number)?;
+				self.record_f64("crawl_cells_success_rate", number).await?;
 			},
 			#[cfg(feature = "crawl")]
 			super::MetricValue::CrawlRowsSuccessRate(number) => {
-				self.record_f64("crawl_rows_success_rate", number)?;
+				self.record_f64("crawl_rows_success_rate", number).await?;
 			},
 		};
 		Ok(())

--- a/src/telemetry/otlp.rs
+++ b/src/telemetry/otlp.rs
@@ -106,8 +106,8 @@ impl super::Metrics for Metrics {
 			super::MetricValue::DHTPutRowsSuccess(number) => {
 				self.record_f64("dht_put_rows_success", number).await?;
 			},
-			super::MetricValue::KadRoutingTablePeerNum(number) => {
-				self.record_u64("kad_routing_table_peer_num", number.into())
+			super::MetricValue::KadRoutingPeerNum(number) => {
+				self.record_u64("kad_routing_table_peer_num", number as u64)
 					.await?;
 			},
 			super::MetricValue::HealthCheck() => {
@@ -130,7 +130,7 @@ impl super::Metrics for Metrics {
 	}
 
 	async fn set_ip(&self, ip: String) {
-		self.set_ip(ip);
+		self.set_ip(ip).await;
 	}
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,6 @@
 
 use std::fmt;
 use std::num::NonZeroUsize;
-use std::str::FromStr;
 use std::time::{Duration, Instant};
 
 use crate::utils::{extract_app_lookup, extract_kate};

--- a/src/types.rs
+++ b/src/types.rs
@@ -373,28 +373,19 @@ pub struct LibP2PConfig {
 	pub identify: IdentifyConfig,
 	pub autonat: AutoNATConfig,
 	pub kademlia: KademliaConfig,
-	pub is_relay: bool,
 	pub relays: Vec<(PeerId, Multiaddr)>,
 	pub bootstrap_interval: Duration,
 }
 
 impl From<&RuntimeConfig> for LibP2PConfig {
 	fn from(val: &RuntimeConfig) -> Self {
-		let relay_nodes = val
-			.relays
-			.iter()
-			.map(|(a, b)| Ok((PeerId::from_str(a)?, b.clone())))
-			.collect::<Result<Vec<(PeerId, Multiaddr)>>>()
-			.expect("To be able to parse relay nodes values from config.");
-
 		Self {
 			secret_key: val.secret_key.clone(),
 			port: val.port,
 			identify: val.into(),
 			autonat: val.into(),
 			kademlia: val.into(),
-			is_relay: val.relays.is_empty(),
-			relays: relay_nodes,
+			relays: val.relays.clone(),
 			bootstrap_interval: Duration::from_secs(val.bootstrap_period),
 		}
 	}

--- a/src/types.rs
+++ b/src/types.rs
@@ -218,7 +218,7 @@ pub struct RuntimeConfig {
 	/// Defines a period of time in which periodic bootstraps will be repeated. (default: 300 sec)
 	pub bootstrap_period: u64,
 	/// Vector of Relay nodes, which are used for hole punching
-	pub relays: Vec<(String, Multiaddr)>,
+	pub relays: Vec<(PeerId, Multiaddr)>,
 	/// WebSocket endpoint of full node for subscribing to latest header, etc (default: [ws://127.0.0.1:9944]).
 	pub full_node_ws: Vec<String>,
 	/// ID of application used to start application client. If app_id is not set, or set to 0, application client is not started (default: 0).

--- a/src/types.rs
+++ b/src/types.rs
@@ -214,7 +214,7 @@ pub struct RuntimeConfig {
 	/// Sets agent version that is sent to peers. (default: "avail-light-client/rust-client")
 	pub identify_agent: String,
 	/// Vector of Light Client bootstrap nodes, used to bootstrap DHT. If not set, light client acts as a bootstrap node, waiting for first peer to connect for DHT bootstrap (default: empty).
-	pub bootstraps: Vec<(String, Multiaddr)>,
+	pub bootstraps: Vec<(PeerId, Multiaddr)>,
 	/// Defines a period of time in which periodic bootstraps will be repeated. (default: 300 sec)
 	pub bootstrap_period: u64,
 	/// Vector of Relay nodes, which are used for hole punching


### PR DESCRIPTION
- Fixed serialization for PeerIds from configs
- Removed unnecessary tasks and channels for metrics in the main loop
- Switched to tokio::RWlock in Metrics
- Added new commands to support network dumping metrics, without the use of event loop output channels
- Changed behavior, where nodes were waiting for connections if they happened to be the first ones in the network [this is now only observed in bootstraps]