### PR TITLE
Introduce support for a second bootstrap node list format

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Config example is for a light client connecting to a local node using a local bo
 # config.yaml
 log_level = "info"
 http_server_host = "127.0.0.1"
-http_server_port = "7000"
+http_server_port = 7000
 
 secret_key = { seed = "avail" }
-port = "37000"
+port = 37000
 
 full_node_ws = ["ws://127.0.0.1:9944"]
 app_id = 0
@@ -74,14 +74,14 @@ log_level = "info"
 # Light client HTTP server host name (default: 127.0.0.1)
 http_server_host = "127.0.0.1"
 # Light client HTTP server port (default: 7000).
-http_server_port = "7000"
+http_server_port = 7000
 # Secret key for libp2p keypair. Can be either set to `seed` or to `key`.
 # If set to seed, keypair will be generated from that seed.
 # If set to key, a valid ed25519 private key must be provided, else the client will fail
 # If `secret_key` is not set, random seed will be used.
 secret_key = { seed={seed} }
 # P2P service port (default: 37000).
-port = 3700
+port = 37000
 # Configures TCP port reuse for local sockets, which implies reuse of listening ports for outgoing connections to enhance NAT traversal capabilities (default: false)
 tcp_port_reuse = bool
 # Configures AutoNAT behaviour to reject probes as a server for clients that are observed at a non-global ip address (default: false)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Response:
 
 ```json
 {
- "latest_block": 10
+	"latest_block": 10
 }
 ```
 
@@ -206,9 +206,9 @@ Response:
 
 ```json
 {
- "block": 1,
- "confidence": 93.75,
- "serialised_confidence": "5232467296"
+	"block": 1,
+	"confidence": 93.75,
+	"serialised_confidence": "5232467296"
 }
 ```
 
@@ -229,10 +229,10 @@ Response:
 
 ```json
 {
- "block": 46,
- "extrinsics": [
-  "ZXhhbXBsZQ=="
- ]
+	"block": 46,
+	"extrinsics": [
+		"ZXhhbXBsZQ=="
+	]
 }
 ```
 
@@ -258,7 +258,7 @@ Response:
 
 ```json
 {
- "AppClient": 1
+	"AppClient": 1
 }
 ```
 
@@ -272,9 +272,9 @@ Response:
 
 ```json
 {
- "block_num": 10,
- "confidence": 93.75,
- "app_id": 1
+	"block_num": 10,
+	"confidence": 93.75,
+	"app_id": 1
 }
 ```
 
@@ -288,7 +288,7 @@ Response:
 
 ```json
 {
- "latest_block": 255
+	"latest_block": 255
 }
 ```
 
@@ -394,10 +394,10 @@ If application data is available, and decode is `false` or unspecified:
 
 ```json
 {
- "block": 1,
- "extrinsics": [
-  "0xc5018400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01308e88ca257b65514b7b44fc1913a6a9af6abc34c3d22761b0e425674d68df7de26be1c8533a7bbd01fdb3a8daa5af77df6d3fb0a67cde8241f461f4fe16f188000000041d011c6578616d706c65"
- ]
+	"block": 1,
+	"extrinsics": [
+		"0xc5018400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01308e88ca257b65514b7b44fc1913a6a9af6abc34c3d22761b0e425674d68df7de26be1c8533a7bbd01fdb3a8daa5af77df6d3fb0a67cde8241f461f4fe16f188000000041d011c6578616d706c65"
+	]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ full_node_ws = ["ws://127.0.0.1:9944"]
 app_id = 0
 confidence = 92.0
 avail_path = "avail_path"
-bootstraps = ["/ip4/127.0.0.1/tcp/37000/12D3KooWMm1c4pzeLPGkkCJMAgFbsfQ8xmVDusg272icWsaNHWzN"]
+bootstraps = ["/ip4/127.0.0.1/tcp/37000/quic-v1/12D3KooWMm1c4pzeLPGkkCJMAgFbsfQ8xmVDusg272icWsaNHWzN"]
 ```
 
 Now, run the client:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ autonat_boot_delay = 10
 identify_protocol = "/avail_kad/id/1.0.0"
 # Sets agent version that is sent to peers. (default: "avail-light-client/rust-client")
 identify_agent = "avail-light-client/rust-client"
-# Vector of Light Client bootstrap nodes, used to bootstrap DHT. If not set, light client acts as a bootstrap node, waiting for first peer to connect for DHT bootstrap (default: empty).
+# Vector of Light Client bootstrap nodes, used to bootstrap the DHT (mandatory field).
 bootstraps = ["/ip4/13.51.79.255/udp/39000/quic-v1/12D3KooWE2xXc6C2JzeaCaEg7jvZLogWyjLsB5dA3iw5o3KcF9ds"]
 # Vector of Relay nodes, which are used for hole punching
 relays = ["/ip4/13.49.44.246/udp/39111/quic-v1/12D3KooWBETtE42fN7DZ5QsGgi7qfrN3jeYdXmBPL4peVTDmgG9b"]

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ http_server_host = "127.0.0.1"
 http_server_port = "7000"
 
 secret_key = { seed = "avail" }
-libp2p_port = "37000"
+port = "37000"
 
 full_node_ws = ["ws://127.0.0.1:9944"]
 app_id = 0
 confidence = 92.0
 avail_path = "avail_path"
-bootstraps = [["12D3KooWMm1c4pzeLPGkkCJMAgFbsfQ8xmVDusg272icWsaNHWzN", "/ip4/127.0.0.1/tcp/37000"]]
+bootstraps = ["/ip4/127.0.0.1/tcp/37000/12D3KooWMm1c4pzeLPGkkCJMAgFbsfQ8xmVDusg272icWsaNHWzN"]
 ```
 
 Now, run the client:
@@ -99,9 +99,9 @@ identify_protocol = "/avail_kad/id/1.0.0"
 # Sets agent version that is sent to peers. (default: "avail-light-client/rust-client")
 identify_agent = "avail-light-client/rust-client"
 # Vector of Light Client bootstrap nodes, used to bootstrap DHT. If not set, light client acts as a bootstrap node, waiting for first peer to connect for DHT bootstrap (default: empty).
-bootstraps = [["12D3KooWE2xXc6C2JzeaCaEg7jvZLogWyjLsB5dA3iw5o3KcF9ds", "/ip4/13.51.79.255/udp/39000/quic-v1"]]
+bootstraps = ["/ip4/13.51.79.255/udp/39000/quic-v1/12D3KooWE2xXc6C2JzeaCaEg7jvZLogWyjLsB5dA3iw5o3KcF9ds"]
 # Vector of Relay nodes, which are used for hole punching
-relays = [["12D3KooWBETtE42fN7DZ5QsGgi7qfrN3jeYdXmBPL4peVTDmgG9b", "/ip4/13.49.44.246/udp/39111/quic-v1"]]
+relays = ["/ip4/13.49.44.246/udp/39111/quic-v1/12D3KooWBETtE42fN7DZ5QsGgi7qfrN3jeYdXmBPL4peVTDmgG9b"]
 # WebSocket endpoint of a full node for subscribing to the latest header, etc (default: ws://127.0.0.1:9944).
 full_node_ws = ["ws://127.0.0.1:9944"]
 # ID of application used to start application client. If app_id is not set, or set to 0, application client is not started (default: 0).
@@ -190,7 +190,7 @@ Response:
 
 ```json
 {
-	"latest_block": 10
+ "latest_block": 10
 }
 ```
 
@@ -206,9 +206,9 @@ Response:
 
 ```json
 {
-	"block": 1,
-	"confidence": 93.75,
-	"serialised_confidence": "5232467296"
+ "block": 1,
+ "confidence": 93.75,
+ "serialised_confidence": "5232467296"
 }
 ```
 
@@ -229,10 +229,10 @@ Response:
 
 ```json
 {
-	"block": 46,
-	"extrinsics": [
-		"ZXhhbXBsZQ=="
-	]
+ "block": 46,
+ "extrinsics": [
+  "ZXhhbXBsZQ=="
+ ]
 }
 ```
 
@@ -258,7 +258,7 @@ Response:
 
 ```json
 {
-	"AppClient": 1
+ "AppClient": 1
 }
 ```
 
@@ -272,9 +272,9 @@ Response:
 
 ```json
 {
-	"block_num": 10,
-	"confidence": 93.75,
-	"app_id": 1
+ "block_num": 10,
+ "confidence": 93.75,
+ "app_id": 1
 }
 ```
 
@@ -288,7 +288,7 @@ Response:
 
 ```json
 {
-	"latest_block": 255
+ "latest_block": 255
 }
 ```
 
@@ -394,10 +394,10 @@ If application data is available, and decode is `false` or unspecified:
 
 ```json
 {
-	"block": 1,
-	"extrinsics": [
-		"0xc5018400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01308e88ca257b65514b7b44fc1913a6a9af6abc34c3d22761b0e425674d68df7de26be1c8533a7bbd01fdb3a8daa5af77df6d3fb0a67cde8241f461f4fe16f188000000041d011c6578616d706c65"
-	]
+ "block": 1,
+ "extrinsics": [
+  "0xc5018400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01308e88ca257b65514b7b44fc1913a6a9af6abc34c3d22761b0e425674d68df7de26be1c8533a7bbd01fdb3a8daa5af77df6d3fb0a67cde8241f461f4fe16f188000000041d011c6578616d706c65"
+ ]
 }
 ```
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use anyhow::Context;
 use avail_subxt::avail;
-use rand::{thread_rng, Rng};
 use rocksdb::DB;
 use std::{
 	net::SocketAddr,
@@ -54,10 +53,6 @@ impl Server {
 			app_id,
 			..
 		} = self.cfg.clone();
-
-		let port = (port.1 > 0)
-			.then(|| thread_rng().gen_range(port.0..=port.1))
-			.unwrap_or(port.0);
 
 		let v1_api = v1::routes(self.db.clone(), app_id, self.state.clone());
 		#[cfg(feature = "api-v2")]

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -126,7 +126,7 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 		warn!("Using default log level: {}", error);
 	}
 
-	if cfg.clone().bootstraps.into_inner().is_empty() {
+	if cfg.bootstraps.is_empty() {
 		Err(anyhow!("Bootstrap node list must not be empty."))?
 	}
 
@@ -181,7 +181,7 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 	// wait here for bootstrap to finish
 	info!("Bootstraping the DHT with bootstrap nodes...");
 	network_client
-		.bootstrap(cfg.clone().bootstraps.into_inner())
+		.bootstrap(cfg.bootstraps.iter().map(Into::into).collect())
 		.await?;
 
 	#[cfg(feature = "network-analysis")]

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -126,6 +126,10 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 		warn!("Using default log level: {}", error);
 	}
 
+	if cfg.clone().bootstraps.into_inner().is_empty() {
+		Err(anyhow!("Bootstrap node list must not be empty."))?
+	}
+
 	let db = init_db(&cfg.avail_path).context("Cannot initialize database")?;
 
 	// If in fat client mode, enable deleting local Kademlia records

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -176,7 +176,9 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 
 	// wait here for bootstrap to finish
 	info!("Bootstraping the DHT with bootstrap nodes...");
-	network_client.bootstrap(cfg.clone().bootstraps).await?;
+	network_client
+		.bootstrap(cfg.clone().bootstraps.into_inner())
+		.await?;
 
 	#[cfg(feature = "network-analysis")]
 	tokio::task::spawn(network_analyzer::start_traffic_analyzer(cfg.port, 10));

--- a/src/types.rs
+++ b/src/types.rs
@@ -177,17 +177,17 @@ mod port_range_format {
 }
 
 #[derive(Serialize, Debug, Clone)]
-pub struct BootstrapConfig(Vec<(PeerId, Multiaddr)>);
+pub struct MultiaddressConfig(Vec<(PeerId, Multiaddr)>);
 
-impl BootstrapConfig {
+impl MultiaddressConfig {
 	pub fn into_inner(self) -> Vec<(PeerId, Multiaddr)> {
 		self.0
 	}
 }
-struct BootstrapConfigVisitor;
+struct MultiaddressConfigVisitor;
 
-impl<'de> Visitor<'de> for BootstrapConfigVisitor {
-	type Value = BootstrapConfig;
+impl<'de> Visitor<'de> for MultiaddressConfigVisitor {
+	type Value = MultiaddressConfig;
 
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
 		formatter.write_str("a Vec<String> or a Vec<(PeerId, Multiaddr)>")
@@ -238,16 +238,16 @@ impl<'de> Visitor<'de> for BootstrapConfigVisitor {
 			}
 		}
 
-		Ok(BootstrapConfig(bootstraps))
+		Ok(MultiaddressConfig(bootstraps))
 	}
 }
 
-impl<'de> Deserialize<'de> for BootstrapConfig {
+impl<'de> Deserialize<'de> for MultiaddressConfig {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: Deserializer<'de>,
 	{
-		deserializer.deserialize_any(BootstrapConfigVisitor)
+		deserializer.deserialize_any(MultiaddressConfigVisitor)
 	}
 }
 
@@ -291,11 +291,11 @@ pub struct RuntimeConfig {
 	/// Sets agent version that is sent to peers. (default: "avail-light-client/rust-client")
 	pub identify_agent: String,
 	/// Vector of Light Client bootstrap nodes, used to bootstrap DHT. If not set, light client acts as a bootstrap node, waiting for first peer to connect for DHT bootstrap (default: empty).
-	pub bootstraps: BootstrapConfig,
+	pub bootstraps: MultiaddressConfig,
 	/// Defines a period of time in which periodic bootstraps will be repeated. (default: 300 sec)
 	pub bootstrap_period: u64,
 	/// Vector of Relay nodes, which are used for hole punching
-	pub relays: Vec<(PeerId, Multiaddr)>,
+	pub relays: MultiaddressConfig,
 	/// WebSocket endpoint of full node for subscribing to latest header, etc (default: [ws://127.0.0.1:9944]).
 	pub full_node_ws: Vec<String>,
 	/// ID of application used to start application client. If app_id is not set, or set to 0, application client is not started (default: 0).
@@ -464,7 +464,7 @@ impl From<&RuntimeConfig> for LibP2PConfig {
 			identify: val.into(),
 			autonat: val.into(),
 			kademlia: val.into(),
-			relays: val.relays.clone(),
+			relays: val.relays.clone().into_inner(),
 			bootstrap_interval: Duration::from_secs(val.bootstrap_period),
 		}
 	}
@@ -594,9 +594,9 @@ impl Default for RuntimeConfig {
 			autonat_boot_delay: 5,
 			identify_protocol: "/avail_kad/id/1.0.0".to_string(),
 			identify_agent: "avail-light-client/rust-client".to_string(),
-			bootstraps: BootstrapConfig(Vec::new()),
+			bootstraps: MultiaddressConfig(Vec::new()),
 			bootstrap_period: 300,
-			relays: Vec::new(),
+			relays: MultiaddressConfig(Vec::new()),
 			full_node_ws: vec!["ws://127.0.0.1:9944".to_owned()],
 			app_id: None,
 			confidence: 92.0,


### PR DESCRIPTION
- Bootstrap list in the config file can now be in a `Vec<String>` while maintaining compatibility with the old format 