### PR TITLE
Config appid default fix

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -631,7 +631,9 @@ impl RuntimeConfig {
 			self.bootstraps = vec![MultiaddrConfig::PeerIdAndMultiaddr(bootstrap)];
 		}
 
-		self.app_id = app_id;
+		if self.app_id.is_none() {
+			self.app_id = app_id;
+		}
 
 		Ok(())
 	}

--- a/src/types.rs
+++ b/src/types.rs
@@ -631,7 +631,7 @@ impl RuntimeConfig {
 			self.bootstraps = vec![MultiaddrConfig::PeerIdAndMultiaddr(bootstrap)];
 		}
 
-		if self.app_id.is_none() {
+		if app_id.is_some() {
 			self.app_id = app_id;
 		}
 


### PR DESCRIPTION
- `appID` flag now overwrites default value as well as config parameter