### PR TITLE
Log verbosity reshuffle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,6 +3678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7322,7 +7331,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "regex",
  "serde",
  "serde_json",
@@ -7341,12 +7350,16 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
+ "matchers 0.1.0",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec 1.11.0",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ threadpool = "1.8.1"
 tokio = { version = "1.25", features = ["full"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.15", features = ["json"] }
+tracing-subscriber = { version = "0.3.15", features = ["json", "env-filter"] }
 uuid = { version = "1.3.4", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
 void = "1.0.2"
 warp = "0.3.6"

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -25,7 +25,7 @@ use tracing::Subscriber;
 use tracing::{error, info, metadata::ParseLevelError, trace, warn, Level};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::{
-	fmt::format::{self, DefaultFields, Format, Json},
+	fmt::format::{self},
 	FmtSubscriber,
 };
 
@@ -47,9 +47,9 @@ const CLIENT_ROLE: &str = if cfg!(feature = "crawl") {
 
 /// Light Client for Avail Blockchain
 
-fn json_subscriber(log_level: Level) -> FmtSubscriber<DefaultFields, Format<Json>> {
+fn json_subscriber(log_level: Level) -> impl Subscriber + Send + Sync {
 	FmtSubscriber::builder()
-		.with_max_level(log_level)
+		.with_env_filter(EnvFilter::new(format!("avail_light={log_level}")))
 		.event_format(format::json())
 		.finish()
 }

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -21,9 +21,11 @@ use tokio::sync::{
 	broadcast,
 	mpsc::{channel, Sender},
 };
+use tracing::Subscriber;
 use tracing::{error, info, metadata::ParseLevelError, trace, warn, Level};
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::{
-	fmt::format::{self, DefaultFields, Format, Full, Json},
+	fmt::format::{self, DefaultFields, Format, Json},
 	FmtSubscriber,
 };
 
@@ -52,9 +54,9 @@ fn json_subscriber(log_level: Level) -> FmtSubscriber<DefaultFields, Format<Json
 		.finish()
 }
 
-fn default_subscriber(log_level: Level) -> FmtSubscriber<DefaultFields, Format<Full>> {
+fn default_subscriber(log_level: Level) -> impl Subscriber + Send + Sync {
 	FmtSubscriber::builder()
-		.with_max_level(log_level)
+		.with_env_filter(EnvFilter::new(format!("avail_light={log_level}")))
 		.with_span_events(format::FmtSpan::CLOSE)
 		.finish()
 }

--- a/src/network/p2p/client.rs
+++ b/src/network/p2p/client.rs
@@ -224,7 +224,7 @@ impl Client {
 
 		match self.get_kad_record(record_key).await {
 			Ok(peer_record) => {
-				debug!("Fetched cell {reference} from the DHT");
+				trace!("Fetched cell {reference} from the DHT");
 
 				let try_content: Result<[u8; config::COMMITMENT_SIZE + config::CHUNK_SIZE], _> =
 					peer_record.record.value.try_into();
@@ -237,7 +237,7 @@ impl Client {
 				Some(Cell { position, content })
 			},
 			Err(error) => {
-				debug!("Cell {reference} not found in the DHT: {error}");
+				trace!("Cell {reference} not found in the DHT: {error}");
 				None
 			},
 		}

--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -183,15 +183,18 @@ impl EventLoop {
 					KademliaEvent::InboundRequest { request } => {
 						trace!("Inbound request: {:?}", request);
 						if let InboundRequest::PutRecord { source, record, .. } = request {
-							let key = &record.as_ref().expect("No record found").key;
-							trace!("Inbound PUT request record key: {key:?}. Source: {source:?}",);
+							match record {
+								Some(rec) => {
+									let key = &rec.key;
+									trace!("Inbound PUT request record key: {key:?}. Source: {source:?}",);
 
-							_ = self
-								.swarm
-								.behaviour_mut()
-								.kademlia
-								.store_mut()
-								.put(record.expect("No record found"));
+									_ = self.swarm.behaviour_mut().kademlia.store_mut().put(rec);
+								},
+								None => {
+									debug!("Received empty cell record from: {source:?}");
+									return;
+								},
+							}
 						}
 					},
 					KademliaEvent::OutboundQueryProgressed { id, result, .. } => match result {


### PR DESCRIPTION
- Suppressed logs from crates other than `avail_light` to ERROR level only
- Added tracing instrumentation to the event handler function in p2p event loop
- Downgraded most of the p2p DEBUG level logs to TRACES
- Fixed a possible panic if the incoming PUT record was empty for whatever reason