### PR TITLE
Swap `crawl_block_delay` from metric to an OT attribute

### DIFF
--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -90,7 +90,7 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 		IdentityConfig::load_or_init("identity.toml", opts.avail_passphrase.as_deref())?;
 
 	let version = clap::crate_version!();
-	info!("Running Avail light client version: {version}");
+	info!("Running Avail light client version: {version}. Mode: {CLIENT_ROLE}.");
 	info!("Using config: {cfg:?}");
 	info!("Avail address is: {}", &identity_cfg.avail_address);
 
@@ -124,6 +124,8 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 			peer_id,
 			CLIENT_ROLE.into(),
 			identity_cfg.avail_address.clone(),
+			#[cfg(feature = "crawl")]
+			cfg.crawl.crawl_block_delay,
 		)
 		.context("Unable to initialize OpenTelemetry service")?,
 	);

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -90,7 +90,7 @@ async fn run(error_sender: Sender<anyhow::Error>) -> Result<()> {
 		IdentityConfig::load_or_init("identity.toml", opts.avail_passphrase.as_deref())?;
 
 	let version = clap::crate_version!();
-	info!("Running Avail light client version: {version}. Mode: {CLIENT_ROLE}.");
+	info!("Running Avail light client version: {version}. Role: {CLIENT_ROLE}.");
 	info!("Using config: {cfg:?}");
 	info!("Avail address is: {}", &identity_cfg.avail_address);
 

--- a/src/crawl_client.rs
+++ b/src/crawl_client.rs
@@ -75,12 +75,6 @@ pub async fn run(
 
 		if let Some(seconds) = delay.sleep_duration(received_at) {
 			info!("Sleeping for {seconds:?} seconds");
-			if let Err(error) = metrics
-				.record(MetricValue::CrawlBlockDelay(seconds.as_secs_f64()))
-				.await
-			{
-				error!("Cannot record crawl block delay: {}", error);
-			}
 			tokio::time::sleep(seconds).await;
 		}
 		let block_number = block.block_num;

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -26,8 +26,6 @@ pub enum MetricValue {
 	CrawlCellsSuccessRate(f64),
 	#[cfg(feature = "crawl")]
 	CrawlRowsSuccessRate(f64),
-	#[cfg(feature = "crawl")]
-	CrawlBlockDelay(f64),
 }
 
 #[automock]


### PR DESCRIPTION
- Changed `crawl_block_delay` from a metric to an OT attribute to be set if the client is in `crawler` mode only
- Added client mode to initial logs