### PR TITLE
Remove disable proof verification configuration

### DIFF
--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -252,7 +252,7 @@ pub async fn run(
 
 	info!("Syncing block headers for {sync_range:?}");
 	for block_number in sync_range {
-		// TODO: This is still an ambigous check since data fetch can fail.
+		// TODO: This is still an ambiguous check since data fetch can fail.
 		// We should write block status in DB explicitly.
 		match sync_client.is_confidence_in_db(block_number) {
 			Ok(false) => (),

--- a/src/types.rs
+++ b/src/types.rs
@@ -252,8 +252,6 @@ pub struct RuntimeConfig {
 	pub ot_collector_endpoint: String,
 	/// Disables fetching of cells from RPC, set to true if client expects cells to be available in DHT (default: false).
 	pub disable_rpc: bool,
-	/// Disables proof verification in general, if set to true, otherwise proof verification is performed. (default: false).
-	pub disable_proof_verification: bool,
 	/// Maximum number of parallel tasks spawned for GET and PUT operations on DHT (default: 20).
 	pub dht_parallelization_limit: usize,
 	/// Number of records to be inserted into DHT simultaneously (default: 1000)
@@ -327,7 +325,6 @@ pub struct LightClientConfig {
 	pub query_proof_rpc_parallel_tasks: usize,
 	pub block_processing_delay: Delay,
 	pub block_matrix_partition: Option<Partition>,
-	pub disable_proof_verification: bool,
 	pub max_cells_per_rpc: usize,
 	pub ttl: u64,
 }
@@ -354,7 +351,6 @@ impl From<&RuntimeConfig> for LightClientConfig {
 			query_proof_rpc_parallel_tasks: val.query_proof_rpc_parallel_tasks,
 			block_processing_delay: Delay(block_processing_delay),
 			block_matrix_partition: val.block_matrix_partition,
-			disable_proof_verification: val.disable_proof_verification,
 			max_cells_per_rpc: val.max_cells_per_rpc.unwrap_or(30),
 			ttl: val.kad_record_ttl,
 		}
@@ -518,7 +514,6 @@ impl Default for RuntimeConfig {
 			log_format_json: false,
 			ot_collector_endpoint: "http://127.0.0.1:4317".to_string(),
 			disable_rpc: false,
-			disable_proof_verification: false,
 			dht_parallelization_limit: 20,
 			put_batch_size: 1000,
 			query_proof_rpc_parallel_tasks: 8,


### PR DESCRIPTION
Since `disable_proof_verification` description is misleading and only
use of this parameter is to disable proof verification during the
confidence check, we can remove this parameter.