### PR TITLE
added peer refresh when encountering WrongPeerID error

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -184,7 +184,7 @@ impl Client for DHTWithRPCFallbackClient {
 			.insert_cells_into_dht(block_number, rpc_fetched.clone())
 			.await
 		{
-			warn!("Error inserting cells into DHT: {error}");
+			debug!("Error inserting cells into DHT: {error}");
 		}
 
 		let stats = FetchStats::new(

--- a/src/network.rs
+++ b/src/network.rs
@@ -10,7 +10,7 @@ use mockall::automock;
 use sp_core::H256;
 use std::{sync::Arc, time::Duration};
 use tokio::time::Instant;
-use tracing::{info, warn};
+use tracing::{debug, info};
 
 use crate::proof;
 

--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -494,7 +494,7 @@ impl EventLoop {
 										debug!("Removed peer: {removed_peer_id} from the routing table");
 
 										match self.swarm.behaviour_mut().kademlia.add_address(
-											&obtained,
+											obtained,
 											endpoint.get_remote_address().clone(),
 										) {
 											kad::RoutingUpdate::Success => {

--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -482,11 +482,39 @@ impl EventLoop {
 						trace!("Outgoing connection error: {error:?}");
 
 						if let Some(peer_id) = peer_id {
-							trace!("OutgoingConnectionError by peer: {peer_id:?}. Error: {error}.");
 							// Notify the connections we're waiting on an error has occured
+							match &error {
+								// If we're getting a WrongPeerId error, remove the peer from the routing table and replace it with obtained one
+								// This action will trigger a routing table update if successful
+								libp2p::swarm::DialError::WrongPeerId { obtained, endpoint } => {
+									if let Some(peer) =
+										self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id)
+									{
+										let removed_peer_id = peer.node.key.preimage();
+										debug!("Removed peer: {removed_peer_id} from the routing table");
+
+										match self.swarm.behaviour_mut().kademlia.add_address(
+											&obtained,
+											endpoint.get_remote_address().clone(),
+										) {
+											kad::RoutingUpdate::Success => {
+												debug!("RoutingUpdate::Success for {obtained}");
+											},
+											kad::RoutingUpdate::Pending => {
+												debug!("RoutingUpdate::Pending for {obtained}");
+											},
+											kad::RoutingUpdate::Failed => {
+												debug!("RoutingUpdate::Failed for {obtained}");
+											},
+										}
+									}
+								},
+								_ => {},
+							}
 							if let Some(ch) = self.pending_swarm_events.remove(&peer_id) {
 								_ = ch.send(Err(error.into()));
 							}
+
 							// remove error producing relay from pending dials
 							// if the peer giving us problems is the chosen relay
 							// just remove it by resetting the reservation state slot


### PR DESCRIPTION
- A `WrongPeerID` error now triggers peer removal re-adding, triggering a routing table update in the process