### PR TITLE
Additional observability

### DIFF
--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -21,7 +21,7 @@ use tokio::{
 };
 use tracing::{debug, error, info, trace, warn};
 
-use crate::telemetry::{MetricValue, Metrics};
+use crate::telemetry::{MetricCounter, MetricValue, Metrics};
 
 use super::{
 	Behaviour, BehaviourEvent, CommandReceiver, EventLoopEntries, QueryChannel, SendableCommand,
@@ -176,9 +176,12 @@ impl EventLoop {
 					kad::Event::PendingRoutablePeer { peer, address } => {
 						trace!("Pending routablePeer. Peer: {peer:?}.  Address: {address:?}");
 					},
-					kad::Event::InboundRequest { request } => {
-						trace!("Inbound request: {:?}", request);
-						if let InboundRequest::PutRecord { source, record, .. } = request {
+					kad::Event::InboundRequest { request } => match request {
+						InboundRequest::GetRecord { .. } => {
+							metrics.count(MetricCounter::IncomingGetRecord).await;
+						},
+						InboundRequest::PutRecord { source, record, .. } => {
+							metrics.count(MetricCounter::IncomingPutRecord).await;
 							match record {
 								Some(rec) => {
 									let key = &rec.key;
@@ -191,7 +194,8 @@ impl EventLoop {
 									return;
 								},
 							}
-						}
+						},
+						_ => {},
 					},
 					kad::Event::OutboundQueryProgressed {
 						id, result, stats, ..
@@ -451,35 +455,21 @@ impl EventLoop {
 							self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
 						}
 					},
-					SwarmEvent::IncomingConnection {
-						local_addr,
-						send_back_addr,
-						..
-					} => {
-						trace!("Incoming connection from address: {send_back_addr:?}. Local address: {local_addr:?}");
+					SwarmEvent::IncomingConnection { .. } => {
+						metrics.count(MetricCounter::IncomingConnection).await;
 					},
-					SwarmEvent::IncomingConnectionError {
-						local_addr,
-						send_back_addr,
-						error,
-						..
-					} => {
-						trace!("Incoming connection error from address: {send_back_addr:?}. Local address: {local_addr:?}. Error: {error:?}.")
+					SwarmEvent::IncomingConnectionError { .. } => {
+						metrics.count(MetricCounter::IncomingConnectionError).await;
 					},
-					SwarmEvent::ConnectionEstablished {
-						peer_id,
-						endpoint,
-						established_in,
-						..
-					} => {
-						trace!("Connection established to: {peer_id:?} via: {endpoint:?} in {established_in:?}. ");
+					SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+						metrics.count(MetricCounter::ConnectionEstablished).await;
 						// Notify the connections we're waiting on that we've connected successfully
 						if let Some(ch) = self.pending_swarm_events.remove(&peer_id) {
 							_ = ch.send(Ok(()));
 						}
 					},
 					SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-						trace!("Outgoing connection error: {error:?}");
+						metrics.count(MetricCounter::OutgoingConnectionError).await;
 
 						if let Some(peer_id) = peer_id {
 							trace!("OutgoingConnectionError by peer: {peer_id:?}. Error: {error}.");

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -37,7 +37,7 @@ impl Display for MetricCounter {
 impl MetricCounter {
 	fn init_counters(meter: Meter) -> HashMap<String, Counter<u64>> {
 		let mut counter_map: HashMap<String, Counter<u64>> = Default::default();
-		for counter in vec![
+		for counter in [
 			MetricCounter::SessionBlock,
 			MetricCounter::OutgoingConnectionError,
 			MetricCounter::IncomingConnectionError,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,11 +1,58 @@
+use std::{
+	collections::HashMap,
+	fmt::{self, Display, Formatter},
+};
+
 use async_trait::async_trait;
 use color_eyre::Result;
 use mockall::automock;
+use opentelemetry_api::metrics::{Counter, Meter};
 
 pub mod otlp;
 
 pub enum MetricCounter {
 	SessionBlock,
+	OutgoingConnectionError,
+	IncomingConnectionError,
+	IncomingConnection,
+	ConnectionEstablished,
+	IncomingPutRecord,
+	IncomingGetRecord,
+}
+
+impl Display for MetricCounter {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		match self {
+			MetricCounter::SessionBlock => write!(f, "session_block_counter"),
+			MetricCounter::OutgoingConnectionError => write!(f, "outgoing_connection_errors"),
+			MetricCounter::IncomingConnectionError => write!(f, "incoming_connection_errors"),
+			MetricCounter::IncomingConnection => write!(f, "incoming_connections"),
+			MetricCounter::ConnectionEstablished => write!(f, "established_connections"),
+			MetricCounter::IncomingPutRecord => write!(f, "incoming_put_record_counter"),
+			MetricCounter::IncomingGetRecord => write!(f, "incoming_get_record_counter"),
+		}
+	}
+}
+
+impl MetricCounter {
+	fn init_counters(meter: Meter) -> HashMap<String, Counter<u64>> {
+		let mut counter_map: HashMap<String, Counter<u64>> = Default::default();
+		for counter in vec![
+			MetricCounter::SessionBlock,
+			MetricCounter::OutgoingConnectionError,
+			MetricCounter::IncomingConnectionError,
+			MetricCounter::IncomingConnection,
+			MetricCounter::ConnectionEstablished,
+			MetricCounter::IncomingPutRecord,
+			MetricCounter::IncomingGetRecord,
+		] {
+			counter_map.insert(
+				counter.to_string(),
+				meter.u64_counter(counter.to_string()).init(),
+			);
+		}
+		counter_map
+	}
 }
 
 pub enum MetricValue {

--- a/src/telemetry/otlp.rs
+++ b/src/telemetry/otlp.rs
@@ -51,19 +51,13 @@ impl Metrics {
 			),
 			KeyValue::new("ip", self.attributes.ip.read().await.clone()),
 			KeyValue::new("avail_address", self.attributes.avail_address.clone()),
-			KeyValue::new(
-				"replication_factor",
-				self.attributes.replication_factor.clone(),
-			),
-			KeyValue::new("query_timeout", self.attributes.query_timeout.clone()),
+			KeyValue::new("replication_factor", self.attributes.replication_factor),
+			KeyValue::new("query_timeout", self.attributes.query_timeout),
 			KeyValue::new(
 				"block_processing_delay",
-				self.attributes.block_processing_delay.clone(),
+				self.attributes.block_processing_delay,
 			),
-			KeyValue::new(
-				"confidence_treshold",
-				self.attributes.confidence_treshold.clone(),
-			),
+			KeyValue::new("confidence_treshold", self.attributes.confidence_treshold),
 			KeyValue::new("partition_size", self.attributes.partition_size.clone()),
 			KeyValue::new("operating_mode", self.attributes.operating_mode.clone()),
 			#[cfg(feature = "crawl")]

--- a/src/telemetry/otlp.rs
+++ b/src/telemetry/otlp.rs
@@ -61,7 +61,10 @@ impl Metrics {
 			KeyValue::new("partition_size", self.attributes.partition_size.clone()),
 			KeyValue::new("operating_mode", self.attributes.operating_mode.clone()),
 			#[cfg(feature = "crawl")]
-			KeyValue::new("crawl_block_delay", self.crawl_block_delay.to_string()),
+			KeyValue::new(
+				"crawl_block_delay",
+				self.attributes.crawl_block_delay.to_string(),
+			),
 		]
 	}
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,6 +20,7 @@ use libp2p::{Multiaddr, PeerId};
 use serde::{de::Error, Deserialize, Serialize};
 use sp_core::crypto::Ss58Codec;
 use sp_core::{blake2_256, bytes, ed25519};
+use std::fmt::{self, Display, Formatter};
 use std::fs;
 use std::num::NonZeroUsize;
 use std::ops::Range;
@@ -116,6 +117,15 @@ impl KademliaMode {
 		match self {
 			KademliaMode::Client => KadMode::Client,
 			KademliaMode::Server => KadMode::Server,
+		}
+	}
+}
+
+impl Display for KademliaMode {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		match self {
+			KademliaMode::Client => write!(f, "client"),
+			KademliaMode::Server => write!(f, "server"),
 		}
 	}
 }


### PR DESCRIPTION
- Added new OpenTelemetry labels -  `operating_mode`, `partition_size`, `confidence_treshold`, `block_processing_delay`, `query_timeout`, `replication_factor`
- Added new OpenTelemetry counters - `outgoing_connection_errors`, `incoming_connection_errors`, `incoming_connections`, `established_connections`, `incoming_put_record_counter`, `incoming_get_record_counter`
- Minor metric refactor