### PR TITLE
added external peer filtering on swarm and kademlia levels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "kate-recovery",
  "libc",
  "libp2p",
+ "libp2p-allow-block-list",
  "mockall",
  "multihash 0.14.0",
  "num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ hyper = { version = "0.14.23", features = ["full", "http1"] }
 itertools = "0.10.5"
 libc = "0.2.150"
 libp2p = { version = "0.53.1", features = ["kad", "identify", "ping", "mdns", "autonat", "relay", "dcutr", "upnp", "noise", "yamux", "dns", "metrics", "tokio", "macros", "tcp", "quic", "serde"] }
+libp2p-allow-block-list = "0.3.0"
 mockall = "0.11.3"
 multihash = { version = "0.14.0", default-features = false, features = ["blake3", "sha3"] }
 num = "0.4.0"

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -1,3 +1,4 @@
+use allow_block_list::BlockedPeers;
 use color_eyre::{eyre::WrapErr, Report, Result};
 use kad_mem_store::{MemoryStore, MemoryStoreConfig};
 use libp2p::{
@@ -5,7 +6,7 @@ use libp2p::{
 	kad::{self, PeerRecord, QueryId},
 	mdns, noise, ping, relay,
 	swarm::NetworkBehaviour,
-	tcp, upnp, yamux, PeerId, Swarm, SwarmBuilder,
+	tcp, upnp, yamux, PeerId, StreamProtocol, Swarm, SwarmBuilder,
 };
 use multihash::{self, Hasher};
 use std::collections::HashMap;
@@ -21,11 +22,15 @@ mod client;
 mod event_loop;
 mod kad_mem_store;
 
-use crate::types::{LibP2PConfig, SecretKey};
+use crate::{
+	network::p2p::event_loop::IdentityData,
+	types::{LibP2PConfig, SecretKey},
+};
 pub use client::Client;
 use event_loop::EventLoop;
 
 use self::client::BlockStat;
+use libp2p_allow_block_list as allow_block_list;
 
 #[derive(Debug)]
 pub enum QueryChannel {
@@ -99,6 +104,7 @@ pub struct Behaviour {
 	relay_client: relay::client::Behaviour,
 	dcutr: dcutr::Behaviour,
 	upnp: upnp::tokio::Behaviour,
+	blocked_peers: allow_block_list::Behaviour<BlockedPeers>,
 }
 
 // Init function initializes all needed needed configs for the functioning
@@ -117,6 +123,11 @@ pub fn init(
 		local_peer_id,
 		id_keys.public()
 	);
+
+	// Use identify protocol_version as Kademlia protocol name
+	let kademlia_protocol_name =
+		StreamProtocol::try_from_owned(cfg.identify.protocol_version.clone())
+			.expect("Invalid Kademlia protocol name");
 
 	// build the Swarm, connecting the lower transport logic with the
 	// higher layer network behaviour logic
@@ -153,11 +164,13 @@ pub fn init(
 					max_peers: cfg.kademlia.caching_max_peers,
 				})
 				.disjoint_query_paths(cfg.kademlia.disjoint_query_paths)
-				.set_record_filtering(kad::StoreInserts::FilterBoth);
+				.set_record_filtering(kad::StoreInserts::FilterBoth)
+				.set_protocol_names(vec![kademlia_protocol_name]);
 
 			// create Identify Protocol Config
-			let identify_cfg = identify::Config::new(cfg.identify.protocol_version, key.public())
-				.with_agent_version(cfg.identify.agent_version);
+			let identify_cfg =
+				identify::Config::new(cfg.identify.protocol_version.clone(), key.public())
+					.with_agent_version(cfg.identify.agent_version.clone());
 
 			// create AutoNAT Client Config
 			let autonat_cfg = autonat::Config {
@@ -182,6 +195,7 @@ pub fn init(
 				auto_nat: autonat::Behaviour::new(key.public().to_peer_id(), autonat_cfg),
 				mdns: mdns::Behaviour::new(mdns::Config::default(), key.public().to_peer_id())?,
 				upnp: upnp::tokio::Behaviour::default(),
+				blocked_peers: allow_block_list::Behaviour::default(),
 			})
 		})?
 		.with_swarm_config(|c| c.with_idle_connection_timeout(cfg.connection_idle_timeout))
@@ -205,6 +219,10 @@ pub fn init(
 			cfg.relays,
 			cfg.bootstrap_interval,
 			is_fat_client,
+			IdentityData {
+				agent_version: cfg.identify.agent_version,
+				protocol_version: cfg.identify.protocol_version.clone(),
+			},
 		),
 	))
 }

--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -299,6 +299,13 @@ impl EventLoop {
 							trace!("Removing and blocking non-avail peer from routing table. Peer: {peer_id}. Agent: {agent_version}. Protocol: {protocol_version}");
 							self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
 							self.swarm.behaviour_mut().blocked_peers.block_peer(peer_id);
+						} else {
+							for addr in listen_addrs {
+								self.swarm
+									.behaviour_mut()
+									.kademlia
+									.add_address(&peer_id, addr);
+							}
 						}
 					},
 					identify::Event::Sent { peer_id } => {


### PR DESCRIPTION
- Swarm level filtering added using `Identify` protocol, with a temporary peer blocking for external non-Avail peers
- Re-introduced the use of Kademlia protocol names as a secondary protection, preventing future merging of Avail Kademlia with outside networks