### PR TITLE
Add genesis_hash to Kademlia protocol id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,16 +187,14 @@ autonat_retry_interval = 10
 autonat_refresh_interval = 30
 # AutoNat on init delay before starting the first probe. (default: 5 sec)
 autonat_boot_delay = 10
-# Sets application-specific version of the protocol family used by the peer. (default: "/avail_kad/id/1.0.0")
-identify_protocol = "/avail_kad/id/1.0.0"
-# Sets agent version that is sent to peers. (default: "avail-light-client/rust-client")
-identify_agent = "avail-light-client/rust-client"
 # Vector of Light Client bootstrap nodes, used to bootstrap the DHT (mandatory field).
 bootstraps = ["/ip4/13.51.79.255/tcp/39000/p2p/12D3KooWE2xXc6C2JzeaCaEg7jvZLogWyjLsB5dA3iw5o3KcF9ds"]
 # Vector of Relay nodes, which are used for hole punching
 relays = ["/ip4/13.49.44.246/tcp/39111/12D3KooWBETtE42fN7DZ5QsGgi7qfrN3jeYdXmBPL4peVTDmgG9b"]
 # WebSocket endpoint of a full node for subscribing to the latest header, etc (default: ws://127.0.0.1:9944).
 full_node_ws = ["ws://127.0.0.1:9944"]
+# Genesis hash of the network you are connecting to. The genesis hash will be checked upon connecting to the node(s) and will also be used to identify you on the p2p network. If you wish to skip the check for development purposes, entering DEV{suffix} instead will skip the check and create a separate p2p network with that identifier.
+genesis_hash = "DEV123"
 # ID of application used to start application client. If app_id is not set, or set to 0, application client is not started (default: 0).
 app_id = 0
 # Confidence threshold, used to calculate how many cells need to be sampled to achieve desired confidence (default: 92.0).

--- a/src/bin/api_compat_test.rs
+++ b/src/bin/api_compat_test.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
 	let db = data::init_db(&command_args.avail_path)?;
 	let state = Arc::new(Mutex::new(State::default()));
 
-	let (rpc_client, _, event_loop) = rpc::init(db, state, &[command_args.url]);
+	let (rpc_client, _, event_loop) = rpc::init(db, state, &[command_args.url], "DEV");
 	tokio::spawn(event_loop.run(EXPECTED_NETWORK_VERSION));
 
 	let mut correct: bool = true;

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -213,8 +213,12 @@ async fn run(error_sender: Sender<Report>) -> Result<()> {
 	trace!("Public params ({public_params_len}): hash: {public_params_hash}");
 
 	let state = Arc::new(Mutex::new(State::default()));
-	let (rpc_client, rpc_events, rpc_event_loop) =
-		rpc::init(db.clone(), state.clone(), &cfg.full_node_ws);
+	let (rpc_client, rpc_events, rpc_event_loop) = rpc::init(
+		db.clone(),
+		state.clone(),
+		&cfg.full_node_ws,
+		&cfg.genesis_hash,
+	);
 
 	// Subscribing to RPC events before first event is published
 	let publish_rpc_event_receiver = rpc_events.subscribe();

--- a/src/network/rpc.rs
+++ b/src/network/rpc.rs
@@ -205,6 +205,7 @@ pub fn init(
 	db: Arc<DB>,
 	state: Arc<Mutex<State>>,
 	nodes: &[String],
+	genesis_hash: &str,
 ) -> (Client, broadcast::Sender<Event>, EventLoop) {
 	// create channel for Event Loop Commands
 	let (command_sender, command_receiver) = mpsc::channel(1000);
@@ -214,7 +215,14 @@ pub fn init(
 	(
 		Client::new(command_sender),
 		event_sender.clone(),
-		EventLoop::new(db, state, Nodes::new(nodes), command_receiver, event_sender),
+		EventLoop::new(
+			db,
+			state,
+			Nodes::new(nodes),
+			command_receiver,
+			event_sender,
+			genesis_hash,
+		),
 	)
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,6 +34,8 @@ const CELL_SIZE: usize = 32;
 const PROOF_SIZE: usize = 48;
 pub const CELL_WITH_PROOF_SIZE: usize = CELL_SIZE + PROOF_SIZE;
 
+pub const DEV_FLAG_GENHASH: &str = "DEV";
+
 #[derive(Parser)]
 #[command(version)]
 pub struct CliOpts {
@@ -292,6 +294,8 @@ pub struct RuntimeConfig {
 	pub relays: Vec<MultiaddrConfig>,
 	/// WebSocket endpoint of full node for subscribing to latest header, etc (default: [ws://127.0.0.1:9944]).
 	pub full_node_ws: Vec<String>,
+	/// Genesis hash of the network to be connected to. Set to a string beginning with "DEV" to connect to any network.
+	pub genesis_hash: String,
 	/// ID of application used to start application client. If app_id is not set, or set to 0, application client is not started (default: 0).
 	pub app_id: Option<u32>,
 	/// Confidence threshold, used to calculate how many cells need to be sampled to achieve desired confidence (default: 92.0).
@@ -526,9 +530,15 @@ pub struct IdentifyConfig {
 
 impl From<&RuntimeConfig> for IdentifyConfig {
 	fn from(val: &RuntimeConfig) -> Self {
+		let mut genhash_short = val.genesis_hash.trim_start_matches("0x").to_string();
+		genhash_short.truncate(6);
 		Self {
 			agent_version: val.identify_agent.clone(),
-			protocol_version: val.identify_protocol.clone(),
+			protocol_version: format!(
+				"{id}-{gen_hash}",
+				id = val.identify_protocol,
+				gen_hash = genhash_short
+			),
 		}
 	}
 }
@@ -589,6 +599,7 @@ impl Default for RuntimeConfig {
 			bootstrap_period: 3600,
 			relays: Vec::new(),
 			full_node_ws: vec!["ws://127.0.0.1:9944".to_owned()],
+			genesis_hash: "DEV".to_owned(),
 			app_id: None,
 			confidence: 99.9,
 			avail_path: "avail_path".to_owned(),
@@ -672,6 +683,13 @@ impl Network {
 			Network::Goldberg => "http://otel.lightclient.goldberg.avail.tools:4317",
 		}
 	}
+
+	fn genesis_hash(&self) -> &str {
+		match self {
+			Network::Local => "DEV",
+			Network::Goldberg => "6f09966420b2608d1947ccfb0f2a362450d1fc7fd902c29b67c906eaa965a7ae",
+		}
+	}
 }
 
 #[derive(Clone)]
@@ -736,6 +754,7 @@ impl RuntimeConfig {
 			self.full_node_ws = vec![network.full_node_ws().to_string()];
 			self.bootstraps = vec![MultiaddrConfig::PeerIdAndMultiaddr(bootstrap)];
 			self.ot_collector_endpoint = network.ot_collector_endpoint().to_string();
+			self.genesis_hash = network.genesis_hash().to_string();
 		}
 
 		if let Some(loglvl) = &opts.verbosity {

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,6 +35,8 @@ const PROOF_SIZE: usize = 48;
 pub const CELL_WITH_PROOF_SIZE: usize = CELL_SIZE + PROOF_SIZE;
 
 pub const DEV_FLAG_GENHASH: &str = "DEV";
+pub const IDENTITY_PROTOCOL: &str = "/avail_kad/id/1.0.0";
+pub const IDENTITY_AGENT: &str = "avail-light-client/rust-client";
 
 #[derive(Parser)]
 #[command(version)]
@@ -281,10 +283,6 @@ pub struct RuntimeConfig {
 	pub autonat_refresh_interval: u64,
 	/// AutoNat on init delay before starting the fist probe. (default: 5 sec)
 	pub autonat_boot_delay: u64,
-	/// Sets application-specific version of the protocol family used by the peer. (default: "/avail_kad/id/1.0.0")
-	pub identify_protocol: String,
-	/// Sets agent version that is sent to peers. (default: "avail-light-client/rust-client")
-	pub identify_agent: String,
 	/// Vector of Light Client bootstrap nodes, used to bootstrap DHT. If not set, light client acts as a bootstrap node, waiting for first peer to connect for DHT bootstrap (default: empty).
 	pub bootstraps: Vec<MultiaddrConfig>,
 	/// Defines a period of time in which periodic bootstraps will be repeated. (default: 300 sec)
@@ -533,10 +531,10 @@ impl From<&RuntimeConfig> for IdentifyConfig {
 		let mut genhash_short = val.genesis_hash.trim_start_matches("0x").to_string();
 		genhash_short.truncate(6);
 		Self {
-			agent_version: val.identify_agent.clone(),
+			agent_version: IDENTITY_AGENT.to_string(),
 			protocol_version: format!(
 				"{id}-{gen_hash}",
-				id = val.identify_protocol,
+				id = IDENTITY_PROTOCOL,
 				gen_hash = genhash_short
 			),
 		}
@@ -593,8 +591,6 @@ impl Default for RuntimeConfig {
 			autonat_retry_interval: 20,
 			autonat_throttle: 1,
 			autonat_boot_delay: 5,
-			identify_protocol: "/avail_kad/id/1.0.0".to_string(),
-			identify_agent: "avail-light-client/rust-client".to_string(),
 			bootstraps: vec![],
 			bootstrap_period: 3600,
 			relays: Vec::new(),


### PR DESCRIPTION
- Add genesis hash to the config instead of persisting it in the DB on first connection. 
- Use (part of) genesis hash in the protocol ID to make sure each testnet/devnet has it's own separate p2p network. 
- Enable use of "DEV*" instead of genesis hash for development purposes (disables checking the hash, creates a separate p2p network).