### PR TITLE
removed address adding on WrongPeerID error

### DIFF
--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -433,31 +433,12 @@ impl EventLoop {
 
 						if let Some(peer_id) = peer_id {
 							// Notify the connections we're waiting on an error has occured
-							if let libp2p::swarm::DialError::WrongPeerId { obtained, endpoint } =
-								&error
-							{
+							if let libp2p::swarm::DialError::WrongPeerId { .. } = &error {
 								if let Some(peer) =
 									self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id)
 								{
 									let removed_peer_id = peer.node.key.preimage();
-									debug!(
-										"Removed peer: {removed_peer_id} from the routing table"
-									);
-
-									match self.swarm.behaviour_mut().kademlia.add_address(
-										obtained,
-										endpoint.get_remote_address().clone(),
-									) {
-										kad::RoutingUpdate::Success => {
-											debug!("RoutingUpdate::Success for {obtained}");
-										},
-										kad::RoutingUpdate::Pending => {
-											debug!("RoutingUpdate::Pending for {obtained}");
-										},
-										kad::RoutingUpdate::Failed => {
-											debug!("RoutingUpdate::Failed for {obtained}");
-										},
-									}
+									debug!("Removed peer {removed_peer_id} from the routing table");
 								}
 							}
 							if let Some(ch) = self.pending_swarm_events.remove(&peer_id) {


### PR DESCRIPTION
- Removed peer address adding on receiving `WrongPeerID` error due to potentially wrong multi-address being used
- We're relying on `identify` protocol to re-introduce peers with changed peerIDs/multi-addresses 