### PR TITLE
P2P network optimizations

### DIFF
--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -24,7 +24,7 @@ mod kad_mem_store;
 
 use crate::{
 	shutdown::Controller,
-	types::{KademliaMode, LibP2PConfig, SecretKey},
+	types::{LibP2PConfig, SecretKey},
 };
 pub use client::Client;
 use event_loop::EventLoop;
@@ -202,11 +202,7 @@ pub fn init(
 		.with_swarm_config(|c| c.with_idle_connection_timeout(cfg.connection_idle_timeout))
 		.build();
 
-	let kad_mode = if is_fat_client {
-		KademliaMode::Server.into()
-	} else {
-		cfg.kademlia_mode.into()
-	};
+	let kad_mode = cfg.kademlia_mode.into();
 
 	// Setting the mode this way disables automatic mode changes.
 	//

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -89,8 +89,8 @@ pub trait Command {
 }
 
 type SendableCommand = Box<dyn Command + Send + Sync>;
-type CommandSender = mpsc::Sender<SendableCommand>;
-type CommandReceiver = mpsc::Receiver<SendableCommand>;
+type CommandSender = mpsc::UnboundedSender<SendableCommand>;
+type CommandReceiver = mpsc::UnboundedReceiver<SendableCommand>;
 
 // Behaviour struct is used to derive delegated Libp2p behaviour implementation
 #[derive(NetworkBehaviour)]
@@ -216,7 +216,7 @@ pub fn init(
 	swarm.behaviour_mut().kademlia.set_mode(Some(kad_mode));
 
 	// create sender channel for Event Loop Commands
-	let (command_sender, command_receiver) = mpsc::channel(10000);
+	let (command_sender, command_receiver) = mpsc::unbounded_channel();
 
 	Ok((
 		Client::new(command_sender, dht_parallelization_limit, ttl),

--- a/src/network/p2p/client.rs
+++ b/src/network/p2p/client.rs
@@ -424,7 +424,6 @@ impl Client {
 		let command = command_with_sender(response_sender);
 		self.command_sender
 			.send(command)
-			.await
 			.wrap_err("receiver should not be dropped")?;
 		response_receiver
 			.await
@@ -444,7 +443,6 @@ impl Client {
 	pub async fn add_address(&self, peer_id: PeerId, peer_addr: Multiaddr) -> Result<()> {
 		self.command_sender
 			.send(Box::new(AddAddress { peer_id, peer_addr }))
-			.await
 			.context("failed to add address to the routing table")
 	}
 
@@ -513,7 +511,6 @@ impl Client {
 				quorum,
 				block_num,
 			}))
-			.await
 			.context("receiver should not be dropped")
 	}
 


### PR DESCRIPTION
- P2P event loop commands channel has been switched from bounded to unbounded
- Fat client implicit Kademlia `server` mode has been removed and is now again read from the config