### PR TITLE
disable port reuse, remove NO_DELAY flag on p2p

### DIFF
--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -135,7 +135,7 @@ pub fn init(
 	let mut swarm = SwarmBuilder::with_existing_identity(id_keys)
 		.with_tokio()
 		.with_tcp(
-			tcp::Config::default().port_reuse(true).nodelay(true),
+			tcp::Config::default().port_reuse(false).nodelay(false),
 			noise::Config::new,
 			yamux::Config::default,
 		)?


### PR DESCRIPTION
- Port reuse disabled due to triggering `Address already in use (os error 48)` on dialling peers
- `NO_DELAY` flag removed because of induced overhead on TCP stack due to very small data chunk (cell) size 
- Port reuse might be re-introduced for certain deployment scenarios in the future