### PR TITLE
246 - RPC Connection Retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "tikv-jemallocator",
  "tiny-bip39",
  "tokio",
+ "tokio-retry",
  "tokio-stream",
  "tokio-util",
  "tracing",
@@ -7692,6 +7693,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ strip-ansi-escapes = "0.2.0"
 threadpool = "1.8.1"
 tiny-bip39 = "1.0.0"
 tokio = { version = "1.35", features = ["full"] }
+tokio-retry = "0.3"
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tokio-util = "0.7.10"
 tracing = "0.1.35"
@@ -68,7 +69,6 @@ tracing-subscriber = { version = "0.3.15", features = ["json", "env-filter"] }
 uuid = { version = "1.3.4", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
 void = "1.0.2"
 warp = "0.3.6"
-tokio-retry = "0.3"
 
 # OpenTelemetry
 opentelemetry = "0.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ tracing-subscriber = { version = "0.3.15", features = ["json", "env-filter"] }
 uuid = { version = "1.3.4", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
 void = "1.0.2"
 warp = "0.3.6"
+tokio-retry = "0.3"
 
 # OpenTelemetry
 opentelemetry = "0.20.0"

--- a/src/bin/api_compat_test.rs
+++ b/src/bin/api_compat_test.rs
@@ -29,8 +29,14 @@ async fn main() -> Result<()> {
 	let db = data::init_db(&command_args.avail_path)?;
 	let state = Arc::new(Mutex::new(State::default()));
 
-	let (rpc_client, _, event_loop) = rpc::init(db, state, &[command_args.url], "DEV");
-	tokio::spawn(event_loop.run(EXPECTED_NETWORK_VERSION));
+	let (rpc_client, _, event_loop) = rpc::init(
+		db,
+		state,
+		&[command_args.url],
+		"DEV",
+		EXPECTED_NETWORK_VERSION,
+	);
+	tokio::spawn(event_loop.run());
 
 	let mut correct: bool = true;
 

--- a/src/bin/api_compat_test.rs
+++ b/src/bin/api_compat_test.rs
@@ -1,6 +1,6 @@
 use avail_light::{
 	data,
-	network::rpc::{self, ExpectedVersion},
+	network::rpc::{self},
 	types::{ExponentialConfig, RetryConfig, State},
 };
 use clap::Parser;
@@ -16,11 +16,6 @@ struct CommandArgs {
 	avail_path: String,
 }
 
-const EXPECTED_NETWORK_VERSION: ExpectedVersion = ExpectedVersion {
-	version: "1.7",
-	spec_name: "data-avail",
-};
-
 #[tokio::main]
 async fn main() -> Result<()> {
 	let command_args = CommandArgs::parse();
@@ -34,14 +29,7 @@ async fn main() -> Result<()> {
 		retries: 4,
 	});
 
-	let (rpc_client, _, event_loop) = rpc::init(
-		db,
-		state,
-		&[command_args.url],
-		"DEV",
-		EXPECTED_NETWORK_VERSION,
-		retry_cfg,
-	);
+	let (rpc_client, _, event_loop) = rpc::init(db, state, &[command_args.url], "DEV", retry_cfg);
 	tokio::spawn(event_loop.run());
 
 	let mut correct: bool = true;

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -3,7 +3,7 @@
 use avail_core::AppId;
 use avail_light::{
 	api,
-	consts::EXPECTED_NETWORK_VERSION,
+	consts::EXPECTED_SYSTEM_VERSION,
 	data,
 	network::p2p,
 	network::{self, rpc},
@@ -215,7 +215,6 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 		state.clone(),
 		&cfg.full_node_ws,
 		&cfg.genesis_hash,
-		EXPECTED_NETWORK_VERSION,
 		cfg.retry_config.clone(),
 	);
 
@@ -271,7 +270,7 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 		identity_cfg,
 		state: state.clone(),
 		version: format!("v{}", clap::crate_version!()),
-		network_version: EXPECTED_NETWORK_VERSION.to_string(),
+		network_version: EXPECTED_SYSTEM_VERSION.to_string(),
 		node_client: rpc_client.clone(),
 		ws_clients: ws_clients.clone(),
 		shutdown: shutdown.clone(),

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -233,7 +233,7 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 	let block_header = match shutdown
 		.with_cancel(rpc::wait_for_finalized_header(
 			first_header_rpc_event_receiver,
-			60,
+			360,
 		))
 		.await
 	{

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -215,6 +215,7 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 		state.clone(),
 		&cfg.full_node_ws,
 		&cfg.genesis_hash,
+		EXPECTED_NETWORK_VERSION,
 	);
 
 	// Subscribing to RPC events before first event is published
@@ -226,8 +227,7 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 
 	// spawn the RPC Network task for Event Loop to run in the background
 	// and shut it down, without delays
-	let rpc_event_loop_handle =
-		tokio::spawn(shutdown.with_cancel(rpc_event_loop.run(EXPECTED_NETWORK_VERSION)));
+	let rpc_event_loop_handle = tokio::spawn(shutdown.with_cancel(rpc_event_loop.run()));
 
 	info!("Waiting for first finalized header...");
 	let block_header = match shutdown

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -27,7 +27,6 @@ use std::{
 	sync::{Arc, Mutex},
 };
 use tokio::sync::{broadcast, RwLock};
-use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tracing::{error, info, metadata::ParseLevelError, trace, warn, Level, Subscriber};
 use tracing_subscriber::{fmt::format, EnvFilter, FmtSubscriber};
 
@@ -211,16 +210,13 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 	trace!("Public params ({public_params_len}): hash: {public_params_hash}");
 
 	let state = Arc::new(Mutex::new(State::default()));
-	let retry_strategy = ExponentialBackoff::from_millis(10)
-		.map(jitter) // add jitter to delays
-		.take(3); // limit to 3 retries
 	let (rpc_client, rpc_events, rpc_event_loop) = rpc::init(
 		db.clone(),
 		state.clone(),
 		&cfg.full_node_ws,
 		&cfg.genesis_hash,
 		EXPECTED_NETWORK_VERSION,
-		retry_strategy,
+		cfg.retry_config.clone(),
 	);
 
 	// Subscribing to RPC events before first event is published

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -12,6 +12,18 @@ pub const APP_DATA_CF: &str = "avail_light_app_data_cf";
 /// Column family for state
 pub const STATE_CF: &str = "avail_light_state_cf";
 
-/// Expected network versions
+/// Expected network Node versions
 pub const EXPECTED_SYSTEM_VERSION: &str = "1.9";
 pub const EXPECTED_SPEC_NAME: &str = "data-avail";
+pub struct ExpectedNodeVariant {
+	pub system_version: &'static str,
+	pub spec_name: &'static str,
+}
+impl ExpectedNodeVariant {
+	pub const fn new() -> Self {
+		Self {
+			system_version: EXPECTED_SYSTEM_VERSION,
+			spec_name: EXPECTED_SPEC_NAME,
+		}
+	}
+}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,7 +1,5 @@
 //! Column family names and other constants.
 
-use crate::network::rpc::ExpectedVersion;
-
 /// Column family for confidence factor
 pub const CONFIDENCE_FACTOR_CF: &str = "avail_light_confidence_factor_cf";
 
@@ -14,8 +12,6 @@ pub const APP_DATA_CF: &str = "avail_light_app_data_cf";
 /// Column family for state
 pub const STATE_CF: &str = "avail_light_state_cf";
 
-/// Expected network version
-pub const EXPECTED_NETWORK_VERSION: ExpectedVersion = ExpectedVersion {
-	version: "1.9",
-	spec_name: "data-avail",
-};
+/// Expected network versions
+pub const EXPECTED_SYSTEM_VERSION: &str = "1.9";
+pub const EXPECTED_SPEC_NAME: &str = "data-avail";

--- a/src/network/rpc.rs
+++ b/src/network/rpc.rs
@@ -130,8 +130,13 @@ impl Node {
 		self
 	}
 
-	pub fn with_system_version(&mut self, system_version: String) -> &mut Self {
-		self.system_version = system_version;
+	pub fn with_spec_name(&mut self, spec_name: &str) -> &mut Self {
+		self.spec_name = spec_name.to_string();
+		self
+	}
+
+	pub fn with_system_version(&mut self, system_version: &str) -> &mut Self {
+		self.system_version = system_version.to_string();
 		self
 	}
 
@@ -146,7 +151,7 @@ impl Default for Node {
 		Self {
 			host: "{host}".to_string(),
 			system_version: "{system_version}".to_string(),
-			spec_name: "{spec_name}".to_string(),
+			spec_name: "data-avail".to_string(),
 			spec_version: 0,
 			genesis_hash: H256::default(),
 		}

--- a/src/network/rpc.rs
+++ b/src/network/rpc.rs
@@ -206,6 +206,7 @@ pub fn init(
 	state: Arc<Mutex<State>>,
 	nodes: &[String],
 	genesis_hash: &str,
+	expected_version: ExpectedVersion<'static>,
 ) -> (Client, broadcast::Sender<Event>, EventLoop) {
 	// create channel for Event Loop Commands
 	let (command_sender, command_receiver) = mpsc::channel(1000);
@@ -222,6 +223,7 @@ pub fn init(
 			command_receiver,
 			event_sender,
 			genesis_hash,
+			expected_version,
 		),
 	)
 }

--- a/src/network/rpc.rs
+++ b/src/network/rpc.rs
@@ -166,18 +166,6 @@ pub struct Nodes {
 }
 
 impl Nodes {
-	pub fn next(&mut self) -> Option<Node> {
-		// we have exhausted all nodes from the list
-		// this is the last one
-		if self.current_index == self.list.len() {
-			None
-		} else {
-			// increment current index
-			self.current_index += 1;
-			self.get_current()
-		}
-	}
-
 	pub fn get_current(&self) -> Option<Node> {
 		let node = &self.list[self.current_index];
 		Some(node.clone())

--- a/src/network/rpc.rs
+++ b/src/network/rpc.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use avail_subxt::{avail, primitives::Header, utils::H256};
-use chrono::format::Item;
 use codec::Decode;
 use color_eyre::{eyre::eyre, Report, Result};
 use kate_recovery::matrix::{Dimensions, Position};
@@ -12,7 +11,6 @@ use std::{
 	collections::HashSet,
 	fmt::Display,
 	sync::{Arc, Mutex},
-	time::Duration,
 };
 use tokio::{
 	sync::{broadcast, mpsc},
@@ -23,7 +21,7 @@ use tracing::{debug, info};
 use crate::{
 	consts::EXPECTED_NETWORK_VERSION,
 	network::rpc,
-	types::{GrandpaJustification, State},
+	types::{GrandpaJustification, RetryConfig, State},
 };
 
 mod client;
@@ -203,14 +201,14 @@ impl Display for ExpectedVersion<'_> {
 	}
 }
 
-pub fn init<T: Iterator<Item = Duration>>(
+pub fn init(
 	db: Arc<DB>,
 	state: Arc<Mutex<State>>,
 	nodes: &[String],
 	genesis_hash: &str,
 	expected_version: ExpectedVersion<'static>,
-	retry_strategy: T,
-) -> (Client, broadcast::Sender<Event>, EventLoop<T>) {
+	retry_config: RetryConfig,
+) -> (Client, broadcast::Sender<Event>, EventLoop) {
 	// create channel for Event Loop Commands
 	let (command_sender, command_receiver) = mpsc::channel(1000);
 	// create output channel for RPC Subscription Events
@@ -227,7 +225,7 @@ pub fn init<T: Iterator<Item = Duration>>(
 			event_sender,
 			genesis_hash,
 			expected_version,
-			retry_strategy,
+			retry_config,
 		),
 	)
 }

--- a/src/network/rpc.rs
+++ b/src/network/rpc.rs
@@ -111,7 +111,7 @@ impl Node {
 	/// Since runtime `spec_version` can be changed with runtime upgrade, `spec_version` is removed.
 	/// NOTE: Runtime compatibility check is currently not implemented.
 	pub fn matches(&self, expected_system_version: &str, expected_spec_name: &str) -> bool {
-		expected_system_version.starts_with(&self.system_version)
+		self.system_version.starts_with(expected_system_version)
 			&& self.spec_name == expected_spec_name
 	}
 

--- a/src/network/rpc.rs
+++ b/src/network/rpc.rs
@@ -19,7 +19,6 @@ use tokio::{
 use tracing::{debug, info};
 
 use crate::{
-	consts::EXPECTED_NETWORK_VERSION,
 	network::rpc,
 	types::{GrandpaJustification, RetryConfig, State},
 };
@@ -79,21 +78,49 @@ impl<'de> Deserialize<'de> for WrappedProof {
 	}
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Node {
 	pub host: String,
 	pub system_version: String,
+	pub spec_name: String,
 	pub spec_version: u32,
 	pub genesis_hash: H256,
 }
 
 impl Node {
+	pub fn new(
+		host: String,
+		system_version: String,
+		spec_name: String,
+		spec_version: u32,
+		genesis_hash: H256,
+	) -> Self {
+		Self {
+			host,
+			system_version,
+			spec_name,
+			spec_version,
+			genesis_hash,
+		}
+	}
+
+	/// Checks if expected version matches network version.
+	/// Since the light client uses subset of the node APIs, `matches` checks only prefix of a node version.
+	/// This means that if expected version is `1.6`, versions `1.6.x` of the node will match.
+	/// Specification name is checked for exact match.
+	/// Since runtime `spec_version` can be changed with runtime upgrade, `spec_version` is removed.
+	/// NOTE: Runtime compatibility check is currently not implemented.
+	pub fn matches(&self, expected_system_version: &str, expected_spec_name: &str) -> bool {
+		expected_system_version.starts_with(&self.system_version)
+			&& self.spec_name == expected_spec_name
+	}
+
 	pub fn network(&self) -> String {
 		format!(
 			"{host}/{system_version}/{spec_name}/{spec_version}",
 			host = self.host,
 			system_version = self.system_version,
-			spec_name = EXPECTED_NETWORK_VERSION.spec_name,
+			spec_name = self.spec_name,
 			spec_version = self.spec_version,
 		)
 	}
@@ -119,22 +146,30 @@ impl Default for Node {
 		Self {
 			host: "{host}".to_string(),
 			system_version: "{system_version}".to_string(),
+			spec_name: "{spec_name}".to_string(),
 			spec_version: 0,
 			genesis_hash: H256::default(),
 		}
 	}
 }
 
+impl Display for Node {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "v{}/{}", self.system_version, self.spec_name)
+	}
+}
+
+#[derive(Clone)]
 pub struct Nodes {
 	list: Vec<Node>,
 	current_index: usize,
 }
 
 impl Nodes {
-	pub fn next_node(&mut self) -> Option<Node> {
+	pub fn next(&mut self) -> Option<Node> {
 		// we have exhausted all nodes from the list
 		// this is the last one
-		if self.current_index == self.list.len() - 1 {
+		if self.current_index == self.list.len() {
 			None
 		} else {
 			// increment current index
@@ -154,6 +189,7 @@ impl Nodes {
 			list: candidates
 				.iter()
 				.map(|s| Node {
+					spec_name: Default::default(),
 					genesis_hash: Default::default(),
 					spec_version: Default::default(),
 					system_version: Default::default(),
@@ -168,36 +204,27 @@ impl Nodes {
 		self.list.shuffle(&mut thread_rng());
 	}
 
-	fn reset(&mut self) -> Option<Node> {
+	fn reset(&mut self) {
 		// shuffle the available list of nodes
 		self.shuffle();
 		// set the current index to the first one
 		self.current_index = 0;
-		self.get_current()
 	}
 }
 
-#[derive(Debug)]
-pub struct ExpectedVersion<'a> {
-	pub version: &'a str,
-	pub spec_name: &'a str,
-}
+impl Iterator for Nodes {
+	type Item = Node;
 
-impl ExpectedVersion<'_> {
-	/// Checks if expected version matches network version.
-	/// Since the light client uses subset of the node APIs, `matches` checks only prefix of a node version.
-	/// This means that if expected version is `1.6`, versions `1.6.x` of the node will match.
-	/// Specification name is checked for exact match.
-	/// Since runtime `spec_version` can be changed with runtime upgrade, `spec_version` is removed.
-	/// NOTE: Runtime compatibility check is currently not implemented.
-	pub fn matches(&self, node_version: &str, spec_name: &str) -> bool {
-		node_version.starts_with(self.version) && self.spec_name == spec_name
-	}
-}
-
-impl Display for ExpectedVersion<'_> {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "v{}/{}", self.version, self.spec_name)
+	fn next(&mut self) -> Option<Self::Item> {
+		if self.current_index == self.list.len() {
+			// reset the iterator when it reaches the end
+			self.reset();
+			None
+		} else {
+			let node = self.get_current();
+			self.current_index += 1;
+			node
+		}
 	}
 }
 
@@ -206,7 +233,6 @@ pub fn init(
 	state: Arc<Mutex<State>>,
 	nodes: &[String],
 	genesis_hash: &str,
-	expected_version: ExpectedVersion<'static>,
 	retry_config: RetryConfig,
 ) -> (Client, broadcast::Sender<Event>, EventLoop) {
 	// create channel for Event Loop Commands
@@ -224,7 +250,6 @@ pub fn init(
 			command_receiver,
 			event_sender,
 			genesis_hash,
-			expected_version,
 			retry_config,
 		),
 	)

--- a/src/network/rpc/event_loop.rs
+++ b/src/network/rpc/event_loop.rs
@@ -111,7 +111,7 @@ impl EventLoop {
 		}
 	}
 
-	async fn connect_node(&mut self) -> Result<()> {
+	async fn connect_node(&mut self, expected: ExpectedNodeVariant) -> Result<()> {
 		// shuffle available Nodes list
 		self.nodes.reset();
 		// start connecting nodes from the config list
@@ -128,10 +128,10 @@ impl EventLoop {
 					warn!(%error, "Failed to connect the Node on: {}. Retrying with {:#?} strategy failed. Skipping to another", node.host, self.retry_config)
 				},
 				Ok((client, node_variant)) => {
-					if !node_variant.matches(EXPECTED_SYSTEM_VERSION, EXPECTED_SPEC_NAME) {
-						return Err(eyre!(
-							"Expected {}, found {}",
-							EXPECTED_SYSTEM_VERSION,
+					if !node_variant.matches(expected.system_version, expected.spec_name) {
+						warn!(
+							"Expected Node system version:{}, found: {}. Skipping to another node.",
+							expected.system_version,
 							node_variant.system_version.clone(),
 						));
 					}

--- a/src/network/rpc/event_loop.rs
+++ b/src/network/rpc/event_loop.rs
@@ -111,7 +111,7 @@ impl EventLoop {
 		}
 	}
 
-	async fn connect_node(&mut self) -> Result<Node> {
+	async fn connect_node(&mut self) -> Result<()> {
 		// shuffle available Nodes list
 		self.nodes.reset();
 		// start connecting nodes from the list
@@ -151,7 +151,7 @@ impl EventLoop {
 						node.host, node_variant.system_version
 					);
 
-					return Ok(node_variant);
+					return Ok(());
 				},
 			}
 		}

--- a/src/network/rpc/event_loop.rs
+++ b/src/network/rpc/event_loop.rs
@@ -241,7 +241,7 @@ impl EventLoop {
 
 	pub async fn run(mut self) -> Result<()> {
 		// try and create Subxt Client
-		self.connect_node().await?;
+		self.connect_node(ExpectedNodeVariant::new()).await?;
 		// try to create RPC Subscription Stream
 		let mut subscriptions_stream = self.stream_subscriptions().await?;
 		// try to get latest Finalized Block Data and set values

--- a/src/network/rpc/event_loop.rs
+++ b/src/network/rpc/event_loop.rs
@@ -114,7 +114,7 @@ impl EventLoop {
 	async fn connect_node(&mut self) -> Result<()> {
 		// shuffle available Nodes list
 		self.nodes.reset();
-		// start connecting nodes from the list
+		// start connecting nodes from the config list
 		for mut node in self.nodes.clone() {
 			// retry connecting node with configured strategy
 			let retry_strategy = self.retry_config.clone().into_iter();

--- a/src/network/rpc/event_loop.rs
+++ b/src/network/rpc/event_loop.rs
@@ -123,15 +123,6 @@ impl EventLoop {
 			.rpc()
 			.request("state_getRuntimeVersion", RpcParams::new())
 			.await?;
-		// client was built successfully, keep it
-		self.set_subxt_client(client);
-
-		node.with_spec_version(runtime_version.spec_version)
-			.with_system_version(system_version.clone())
-			.with_genesis_hash(genesis_hash);
-		// connecting to the selected node was a success,
-		// put it in the state, for all to use
-		self.store_node_data(node.clone())?;
 
 		let version = format!(
 			"v/{}/{}/{}",
@@ -144,6 +135,16 @@ impl EventLoop {
 		{
 			return Err(eyre!("Expected {}, found {version}", self.expected_version));
 		}
+
+		// client was built successfully, keep it
+		self.set_subxt_client(client);
+
+		node.with_spec_version(runtime_version.spec_version)
+			.with_system_version(system_version.clone())
+			.with_genesis_hash(genesis_hash);
+		// connecting to the selected node was a success,
+		// put it in the state, for all to use
+		self.store_node_data(node.clone())?;
 
 		info!(
 			"Connection established to the Node: {:?} <{version}>",

--- a/src/network/rpc/event_loop.rs
+++ b/src/network/rpc/event_loop.rs
@@ -133,7 +133,8 @@ impl EventLoop {
 							"Expected Node system version:{}, found: {}. Skipping to another node.",
 							expected.system_version,
 							node_variant.system_version.clone(),
-						));
+						);
+						continue;
 					}
 
 					// client was built successfully, keep it

--- a/src/network/rpc/event_loop.rs
+++ b/src/network/rpc/event_loop.rs
@@ -31,7 +31,7 @@ use tracing::{debug, info, trace, warn};
 
 use super::{CommandReceiver, Node, Nodes, SendableCommand};
 use crate::{
-	consts::{EXPECTED_SPEC_NAME, EXPECTED_SYSTEM_VERSION},
+	consts::ExpectedNodeVariant,
 	data::store_finality_sync_checkpoint,
 	types::{
 		FinalitySyncCheckpoint, GrandpaJustification, OptionBlockRange, RetryConfig,

--- a/src/types.rs
+++ b/src/types.rs
@@ -726,7 +726,7 @@ impl Default for RuntimeConfig {
 			retry_config: RetryConfig::Exponential(ExponentialConfig {
 				base: 10,
 				max_delay: 4000,
-				retries: 4,
+				retries: 3,
 			}),
 		}
 	}

--- a/src/types.rs
+++ b/src/types.rs
@@ -410,6 +410,13 @@ pub struct RuntimeConfig {
 	pub max_kad_record_size: u64,
 	/// The maximum number of provider records for which the local node is the provider. (default: 1024).
 	pub max_kad_provided_keys: u64,
+	/// Set the configuration based on which the retries will be orchestrated, max duration between retries and number of tries.
+	/// (default:
+	/// exponential:
+	///     base: 10,
+	///     max_delay: 4000,
+	///     retries: 4,
+	/// )
 	pub retry_config: RetryConfig,
 	#[cfg(feature = "crawl")]
 	#[serde(flatten)]


### PR DESCRIPTION
RPC Client now has a mechanism that enables it to retry its connection attempts, in case something fails. Retry scenarios can be set through the config file.