### PR TITLE
Metrics reshuffle

### DIFF
--- a/src/crawl_client.rs
+++ b/src/crawl_client.rs
@@ -76,6 +76,9 @@ pub async fn run(
 		if let Some(seconds) = delay.sleep_duration(received_at) {
 			info!("Sleeping for {seconds:?} seconds");
 			tokio::time::sleep(seconds).await;
+			let _ = metrics
+				.record(MetricValue::CrawlBlockDelay(seconds.as_secs() as f64))
+				.await;
 		}
 		let block_number = block.block_num;
 		info!(block_number, "Crawling block...");

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -10,9 +10,17 @@ use crate::{
 	types::BlockVerified,
 };
 
+#[derive(Clone, Copy)]
+pub struct StaticConfigParams {
+	pub block_confidence_treshold: f64,
+	pub replication_factor: u16,
+	pub query_timeout: u32,
+}
+
 pub async fn process_block(
 	block_number: u32,
 	p2p_client: &P2pClient,
+	static_config_params: StaticConfigParams,
 	metrics: &Arc<impl Metrics>,
 ) -> Result<()> {
 	p2p_client
@@ -29,6 +37,21 @@ pub async fn process_block(
 	let peers_num_metric = MetricValue::KadRoutingPeerNum(peers_num);
 
 	metrics.record(peers_num_metric).await?;
+	metrics
+		.record(MetricValue::BlockConfidenceTreshold(
+			static_config_params.block_confidence_treshold,
+		))
+		.await?;
+	metrics
+		.record(MetricValue::ReplicationFactor(
+			static_config_params.replication_factor,
+		))
+		.await?;
+	metrics
+		.record(MetricValue::QueryTimeout(
+			static_config_params.query_timeout,
+		))
+		.await?;
 	metrics.record(MetricValue::HealthCheck()).await?;
 
 	debug!(block_number, "Maintenance completed");
@@ -39,13 +62,16 @@ pub async fn run(
 	p2p_client: P2pClient,
 	metrics: Arc<impl Metrics>,
 	mut block_receiver: broadcast::Receiver<BlockVerified>,
+	static_config_params: StaticConfigParams,
 	shutdown: Controller<String>,
 ) {
 	info!("Starting maintenance...");
 
 	loop {
 		let result = match block_receiver.recv().await {
-			Ok(block) => process_block(block.block_num, &p2p_client, &metrics).await,
+			Ok(block) => {
+				process_block(block.block_num, &p2p_client, static_config_params, &metrics).await
+			},
 			Err(error) => Err(error.into()),
 		};
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -63,16 +63,21 @@ pub enum MetricValue {
 	NodeRPCFetched(f64),
 	NodeRPCFetchDuration(f64),
 	BlockConfidence(f64),
+	BlockConfidenceTreshold(f64),
 	RPCCallDuration(f64),
 	DHTPutDuration(f64),
 	DHTPutSuccess(f64),
 	KadRoutingPeerNum(usize),
 	HealthCheck(),
 	BlockProcessingDelay(f64),
+	ReplicationFactor(u16),
+	QueryTimeout(u32),
 	#[cfg(feature = "crawl")]
 	CrawlCellsSuccessRate(f64),
 	#[cfg(feature = "crawl")]
 	CrawlRowsSuccessRate(f64),
+	#[cfg(feature = "crawl")]
+	CrawlBlockDelay(f64),
 }
 
 #[automock]

--- a/src/telemetry/otlp.rs
+++ b/src/telemetry/otlp.rs
@@ -11,7 +11,7 @@ use tokio::sync::RwLock;
 
 use super::MetricCounter;
 
-const ATTRIBUTE_NUMBER: usize = if cfg!(feature = "crawl") { 14 } else { 13 };
+const ATTRIBUTE_NUMBER: usize = 9;
 
 #[derive(Debug)]
 pub struct Metrics {
@@ -29,13 +29,7 @@ pub struct MetricAttributes {
 	pub origin: String,
 	pub avail_address: String,
 	pub operating_mode: String,
-	pub replication_factor: i64,
-	pub query_timeout: i64,
-	pub block_processing_delay: i64,
-	pub confidence_treshold: i64,
 	pub partition_size: String,
-	#[cfg(feature = "crawl")]
-	pub crawl_block_delay: u64,
 }
 
 impl Metrics {
@@ -51,20 +45,8 @@ impl Metrics {
 			),
 			KeyValue::new("ip", self.attributes.ip.read().await.clone()),
 			KeyValue::new("avail_address", self.attributes.avail_address.clone()),
-			KeyValue::new("replication_factor", self.attributes.replication_factor),
-			KeyValue::new("query_timeout", self.attributes.query_timeout),
-			KeyValue::new(
-				"block_processing_delay",
-				self.attributes.block_processing_delay,
-			),
-			KeyValue::new("confidence_treshold", self.attributes.confidence_treshold),
 			KeyValue::new("partition_size", self.attributes.partition_size.clone()),
 			KeyValue::new("operating_mode", self.attributes.operating_mode.clone()),
-			#[cfg(feature = "crawl")]
-			KeyValue::new(
-				"crawl_block_delay",
-				self.attributes.crawl_block_delay.to_string(),
-			),
 		]
 	}
 
@@ -128,6 +110,9 @@ impl super::Metrics for Metrics {
 			super::MetricValue::BlockConfidence(number) => {
 				self.record_f64("block_confidence", number).await?;
 			},
+			super::MetricValue::BlockConfidenceTreshold(number) => {
+				self.record_f64("block_confidence_treshold", number).await?;
+			},
 			super::MetricValue::RPCCallDuration(number) => {
 				self.record_f64("rpc_call_duration", number).await?;
 			},
@@ -147,6 +132,12 @@ impl super::Metrics for Metrics {
 			super::MetricValue::BlockProcessingDelay(number) => {
 				self.record_f64("block_processing_delay", number).await?;
 			},
+			super::MetricValue::ReplicationFactor(number) => {
+				self.record_f64("replication_factor", number as f64).await?;
+			},
+			super::MetricValue::QueryTimeout(number) => {
+				self.record_f64("query_timeout", number as f64).await?;
+			},
 			#[cfg(feature = "crawl")]
 			super::MetricValue::CrawlCellsSuccessRate(number) => {
 				self.record_f64("crawl_cells_success_rate", number).await?;
@@ -154,6 +145,10 @@ impl super::Metrics for Metrics {
 			#[cfg(feature = "crawl")]
 			super::MetricValue::CrawlRowsSuccessRate(number) => {
 				self.record_f64("crawl_rows_success_rate", number).await?;
+			},
+			#[cfg(feature = "crawl")]
+			super::MetricValue::CrawlBlockDelay(number) => {
+				self.record_f64("crawl_block_delay", number).await?;
 			},
 		};
 		Ok(())


### PR DESCRIPTION
- `query_timeout`, `replication_factor`, `block_confidence_treshold` and `crawl_block_delay` are now regular metrics and not attributes
- Maintenance module is responsible for sending out static config params in the future