### PR TITLE
479 - RPC Calls with Retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,7 +599,6 @@ dependencies = [
  "confy",
  "derive_more",
  "dusk-plonk",
- "exponential-backoff",
  "futures",
  "hex",
  "hex-literal",
@@ -2321,15 +2320,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "exponential-backoff"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f78d87d930eee4b5686a2ab032de499c72bd1e954b84262bb03492a0f932cd"
-dependencies = [
- "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +587,7 @@ name = "avail-light"
 version = "1.7.6"
 dependencies = [
  "async-std",
+ "async-stream",
  "async-trait",
  "avail-core 0.5.1 (git+https://github.com/availproject/avail-core?tag=kate-recovery/v0.9.2)",
  "avail-subxt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,7 @@ dependencies = [
  "confy",
  "derive_more",
  "dusk-plonk",
+ "exponential-backoff",
  "futures",
  "hex",
  "hex-literal",
@@ -2320,6 +2321,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "exponential-backoff"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f78d87d930eee4b5686a2ab032de499c72bd1e954b84262bb03492a0f932cd"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ kate-recovery = { version = "0.9", git = "https://github.com/availproject/avail-
 
 # 3rd-party
 async-std = { version = "1.12.0", features = ["attributes"] }
+async-stream = "0.3.5"
 async-trait = "0.1.66"
 base64 = "0.21.0"
 better-panic = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ tracing-subscriber = { version = "0.3.15", features = ["json", "env-filter"] }
 uuid = { version = "1.3.4", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
 void = "1.0.2"
 warp = "0.3.6"
-exponential-backoff = "1.2.0"
 
 # OpenTelemetry
 opentelemetry = "0.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ tracing-subscriber = { version = "0.3.15", features = ["json", "env-filter"] }
 uuid = { version = "1.3.4", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
 void = "1.0.2"
 warp = "0.3.6"
+exponential-backoff = "1.2.0"
 
 # OpenTelemetry
 opentelemetry = "0.20.0"

--- a/src/api/v2/mod.rs
+++ b/src/api/v2/mod.rs
@@ -185,7 +185,7 @@ pub fn routes(
 	state: Arc<Mutex<State>>,
 	config: RuntimeConfig,
 	identity_config: IdentityConfig,
-	node_client: Client,
+	rpc_client: Client,
 	ws_clients: WsClients,
 	db: RocksDB,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
@@ -199,7 +199,7 @@ pub fn routes(
 
 	let submitter = app_id.map(|&app_id| {
 		Arc::new(transactions::Submitter {
-			node_client,
+			rpc_client,
 			app_id,
 			pair_signer,
 		})

--- a/src/api/v2/transactions.rs
+++ b/src/api/v2/transactions.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use avail_subxt::{api, primitives::AvailExtrinsicParams, AvailConfig};
-use color_eyre::{eyre::WrapErr, Result};
+use color_eyre::Result;
 use sp_core::sr25519::Pair;
 use subxt::tx::PairSigner;
 

--- a/src/api/v2/transactions.rs
+++ b/src/api/v2/transactions.rs
@@ -14,7 +14,7 @@ pub trait Submit {
 
 #[derive(Clone)]
 pub struct Submitter {
-	pub node_client: rpc::Client,
+	pub rpc_client: rpc::Client,
 	pub app_id: u32,
 	pub pair_signer: PairSigner<AvailConfig, Pair>,
 }
@@ -22,36 +22,32 @@ pub struct Submitter {
 #[async_trait]
 impl Submit for Submitter {
 	async fn submit(&self, transaction: Transaction) -> Result<SubmitResponse> {
-		let tx_progress = match transaction {
+		let ex_event = match transaction {
 			Transaction::Data(data) => {
 				let extrinsic = api::tx().data_availability().submit_data(data.into());
 				let params = AvailExtrinsicParams::new_with_app_id(self.app_id.into());
-				self.node_client
-					.submit_signed_and_watch(extrinsic, self.pair_signer.clone(), params)
+				self.rpc_client
+					.submit_signed_and_wait_for_finalized(&extrinsic, &self.pair_signer, params)
 					.await?
 			},
 			Transaction::Extrinsic(extrinsic) => {
-				self.node_client
-					.submit_from_bytes_and_watch(extrinsic.into())
+				self.rpc_client
+					.submit_from_bytes_and_wait_for_finalized(extrinsic.into())
 					.await?
 			},
 		};
-		let event = tx_progress
-			.wait_for_finalized_success()
-			.await
-			.wrap_err("Cannot sign and submit transaction")?;
 
 		let block_number = self
-			.node_client
-			.get_header_by_hash(event.block_hash())
+			.rpc_client
+			.get_header_by_hash(ex_event.block_hash())
 			.await?
 			.number;
 
 		Ok(SubmitResponse {
 			block_number,
-			block_hash: event.block_hash(),
-			hash: event.extrinsic_hash(),
-			index: event.extrinsic_index(),
+			block_hash: ex_event.block_hash(),
+			hash: ex_event.extrinsic_hash(),
+			index: ex_event.extrinsic_index(),
 		})
 	}
 }

--- a/src/bin/api_compat_test.rs
+++ b/src/bin/api_compat_test.rs
@@ -29,8 +29,9 @@ async fn main() -> Result<()> {
 		retries: 4,
 	});
 
-	let (rpc_client, _, event_loop) = rpc::init(db, state, &[command_args.url], "DEV", retry_cfg);
-	tokio::spawn(event_loop.run());
+	let (rpc_client, _, subscriptions) =
+		rpc::init(db, state, &[command_args.url], "DEV", retry_cfg).await?;
+	tokio::spawn(subscriptions.run());
 
 	let mut correct: bool = true;
 

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -220,7 +220,10 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 
 	// spawn the RPC Network task for Event Loop to run in the background
 	// and shut it down, without delays
-	let rpc_subscriptions_handle = tokio::spawn(shutdown.with_cancel(rpc_subscriptions.run()));
+	let rpc_subscriptions_handle = tokio::spawn(shutdown.with_cancel(shutdown.with_trigger(
+		"Subscription loop ended or failed".to_string(),
+		rpc_subscriptions.run(),
+	)));
 
 	info!("Waiting for first finalized header...");
 	let block_header = match shutdown

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -202,13 +202,14 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 	trace!("Public params ({public_params_len}): hash: {public_params_hash}");
 
 	let state = Arc::new(Mutex::new(State::default()));
-	let (rpc_client, rpc_events, rpc_event_loop) = rpc::init(
+	let (rpc_client, rpc_events, rpc_subscriptions) = rpc::init(
 		db.clone(),
 		state.clone(),
 		&cfg.full_node_ws,
 		&cfg.genesis_hash,
 		cfg.retry_config.clone(),
-	);
+	)
+	.await?;
 
 	// Subscribing to RPC events before first event is published
 	let publish_rpc_event_receiver = rpc_events.subscribe();
@@ -219,7 +220,7 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 
 	// spawn the RPC Network task for Event Loop to run in the background
 	// and shut it down, without delays
-	let rpc_event_loop_handle = tokio::spawn(shutdown.with_cancel(rpc_event_loop.run()));
+	let rpc_subscriptions_handle = tokio::spawn(shutdown.with_cancel(rpc_subscriptions.run()));
 
 	info!("Waiting for first finalized header...");
 	let block_header = match shutdown
@@ -230,20 +231,20 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 		.await
 	{
 		Ok(Err(report)) => {
-			if !rpc_event_loop_handle.is_finished() {
+			if !rpc_subscriptions_handle.is_finished() {
 				return Err(report);
 			}
-			let Ok(Ok(Err(event_loop_error))) = rpc_event_loop_handle.await else {
+			let Ok(Ok(Err(subscriptions_error))) = rpc_subscriptions_handle.await else {
 				return Err(report);
 			};
-			return Err(eyre!(event_loop_error));
+			return Err(eyre!(subscriptions_error));
 		},
 		Ok(Ok(num)) => num,
 		Err(shutdown_reason) => {
-			if !rpc_event_loop_handle.is_finished() {
+			if !rpc_subscriptions_handle.is_finished() {
 				return Err(eyre!(shutdown_reason));
 			}
-			let Ok(Ok(Err(event_loop_error))) = rpc_event_loop_handle.await else {
+			let Ok(Ok(Err(event_loop_error))) = rpc_subscriptions_handle.await else {
 				return Err(eyre!(shutdown_reason));
 			};
 			return Err(eyre!(event_loop_error));

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -15,6 +15,8 @@ pub const STATE_CF: &str = "avail_light_state_cf";
 /// Expected network Node versions
 pub const EXPECTED_SYSTEM_VERSION: &str = "1.10";
 pub const EXPECTED_SPEC_NAME: &str = "data-avail";
+
+#[derive(Clone)]
 pub struct ExpectedNodeVariant {
 	pub system_version: &'static str,
 	pub spec_name: &'static str,
@@ -25,5 +27,15 @@ impl ExpectedNodeVariant {
 			system_version: EXPECTED_SYSTEM_VERSION,
 			spec_name: EXPECTED_SPEC_NAME,
 		}
+	}
+
+	/// Checks if expected version matches provided network version.
+	/// Since the light client uses subset of the node APIs, `matches` checks only prefix of a node version.
+	/// This means that if expected version is `1.6`, versions `1.6.x` of the node will match.
+	/// Specification name is checked for exact match.
+	/// Since runtime `spec_version` can be changed with runtime upgrade, `spec_version` is removed.
+	/// NOTE: Runtime compatibility check is currently not implemented.
+	pub fn matches(&self, system_version: &str, spec_name: &str) -> bool {
+		self.system_version.starts_with(system_version) && self.spec_name == spec_name
 	}
 }

--- a/src/network/rpc.rs
+++ b/src/network/rpc.rs
@@ -86,7 +86,7 @@ pub struct Node {
 	pub system_version: String,
 	pub spec_name: String,
 	pub spec_version: u32,
-	pub genesis_hash: String,
+	pub genesis_hash: H256,
 }
 
 impl Node {
@@ -95,14 +95,14 @@ impl Node {
 		system_version: String,
 		spec_name: String,
 		spec_version: u32,
-		genesis_hash: &str,
+		genesis_hash: H256,
 	) -> Self {
 		Self {
 			host,
 			system_version,
 			spec_name,
 			spec_version,
-			genesis_hash: genesis_hash.to_string(),
+			genesis_hash,
 		}
 	}
 
@@ -166,7 +166,9 @@ impl Nodes {
 	fn shuffle(&self, current_host: String) -> Vec<Node> {
 		let mut list: Vec<Node> = self
 			.list
-			.iter().filter(|&Node { host, .. }| host != &current_host).cloned()
+			.iter()
+			.filter(|&Node { host, .. }| host != &current_host)
+			.cloned()
 			.collect();
 		list.shuffle(&mut thread_rng());
 		list

--- a/src/network/rpc.rs
+++ b/src/network/rpc.rs
@@ -166,9 +166,7 @@ impl Nodes {
 	fn shuffle(&self, current_host: String) -> Vec<Node> {
 		let mut list: Vec<Node> = self
 			.list
-			.iter()
-			.cloned()
-			.filter(|Node { host, .. }| host != &current_host)
+			.iter().filter(|&Node { host, .. }| host != &current_host).cloned()
 			.collect();
 		list.shuffle(&mut thread_rng());
 		list

--- a/src/network/rpc.rs
+++ b/src/network/rpc.rs
@@ -203,21 +203,27 @@ impl Nodes {
 		// set the current index to the first one
 		self.current_index = 0;
 	}
+
+	pub fn iter(&self) -> NodesIterator {
+		NodesIterator {
+			nodes: self,
+			current_index: 0,
+		}
+	}
 }
 
-impl Iterator for Nodes {
-	type Item = Node;
+pub struct NodesIterator<'a> {
+	nodes: &'a Nodes,
+	current_index: usize,
+}
+
+impl<'a> Iterator for NodesIterator<'a> {
+	type Item = &'a Node;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		if self.current_index == self.list.len() {
-			// reset the iterator when it reaches the end
-			self.reset();
-			None
-		} else {
-			let node = self.get_current();
-			self.current_index += 1;
-			node
-		}
+		let res = self.nodes.list.get(self.current_index);
+		self.current_index += 1;
+		res
 	}
 }
 

--- a/src/network/rpc/client.rs
+++ b/src/network/rpc/client.rs
@@ -139,7 +139,7 @@ impl Client {
 		// after a successful connection, try to execute passed call predicate
 		for Node { host, .. } in nodes.iter() {
 			let result =
-				Self::create_subxt_client(&host, expected_node.clone(), expected_genesis_hash)
+				Self::create_subxt_client(host, expected_node.clone(), expected_genesis_hash)
 					.and_then(move |(client, node)| {
 						predicate(client.clone()).map_ok(|res| (client, node, res))
 					})
@@ -194,7 +194,7 @@ impl Client {
 		// create Header subscription
 		let header_subscription = client.rpc().subscribe_finalized_block_headers().await?;
 		// map Header subscription to the same type for later matching
-		let headers = header_subscription.map_ok(|h| Subscription::Header(h));
+		let headers = header_subscription.map_ok(Subscription::Header);
 
 		let justification_subscription = client
 			.rpc()
@@ -205,7 +205,7 @@ impl Client {
 			)
 			.await?;
 		// map Justification subscription to the same type for later matching
-		let justifications = justification_subscription.map_ok(|j| Subscription::Justification(j));
+		let justifications = justification_subscription.map_ok(Subscription::Justification);
 
 		Ok(headers.merge(justifications))
 	}
@@ -456,7 +456,7 @@ impl Client {
 				async move {
 					client
 						.rpc()
-						.storage_keys_paged(&key, count, start_key.as_deref(), hash)
+						.storage_keys_paged(key, count, start_key.as_deref(), hash)
 						.await
 				}
 			})

--- a/src/network/rpc/client.rs
+++ b/src/network/rpc/client.rs
@@ -119,7 +119,7 @@ impl Client {
 			system_version,
 			runtime_version.spec_name,
 			runtime_version.spec_version,
-			&genesis_hash.to_string(),
+			genesis_hash,
 		);
 
 		Ok((client, variant))
@@ -138,12 +138,15 @@ impl Client {
 		// go through the provided list of Nodes to try and find and appropriate one,
 		// after a successful connection, try to execute passed call predicate
 		for Node { host, .. } in nodes.iter() {
-			let result =
-				Self::create_subxt_client(host, expected_node.clone(), expected_genesis_hash)
-					.and_then(move |(client, node)| {
-						predicate(client.clone()).map_ok(|res| (client, node, res))
-					})
-					.await;
+			let result = Self::create_subxt_client(
+				host,
+				expected_node.clone(),
+				expected_genesis_hash,
+			)
+			.and_then(move |(client, node)| {
+				predicate(client.clone()).map_ok(|res| (client, node, res))
+			})
+			.await;
 
 			match result {
 				Err(error) => warn!(host, %error, "Skipping connection with this node"),
@@ -175,7 +178,7 @@ impl Client {
 		let (client, node, result) = Self::connect_nodes_until_success(
 			nodes,
 			ExpectedNodeVariant::new(),
-			&connected_node.genesis_hash,
+			&connected_node.genesis_hash.to_string(),
 			move |client| predicate(client).map_err(Report::from),
 		)
 		.await?;

--- a/src/network/rpc/client.rs
+++ b/src/network/rpc/client.rs
@@ -316,7 +316,7 @@ impl Client {
 		positions: &[Position],
 	) -> Result<Vec<Cell>> {
 		let mut params = RpcParams::new();
-		params.push(positions.clone())?;
+		params.push(positions)?;
 		params.push(block_hash)?;
 
 		let proofs: Vec<u8> = self

--- a/src/network/rpc/client.rs
+++ b/src/network/rpc/client.rs
@@ -1,612 +1,287 @@
-use async_trait::async_trait;
 use avail_subxt::{
-	api::{
-		self, data_availability::calls::types::SubmitData,
-		runtime_types::sp_core::crypto::KeyTypeId,
-	},
-	avail::Pair,
-	primitives::{AvailExtrinsicParams, Header},
+	api::{self, runtime_types::sp_core::crypto::KeyTypeId},
+	avail::{self, Pair},
+	build_client,
+	primitives::Header,
 	utils::H256,
 	AvailConfig,
 };
-use color_eyre::{
-	eyre::{eyre, WrapErr},
-	Report, Result,
-};
+use color_eyre::{eyre::eyre, Report, Result};
+use futures::{Stream, TryFutureExt, TryStreamExt};
 use kate_recovery::{data::Cell, matrix::Position};
-use sp_core::ed25519::{self, Public};
+use sp_core::{
+	bytes::from_hex,
+	ed25519::{self, Public},
+};
+use std::sync::Arc;
 use subxt::{
 	rpc::{types::BlockNumber, RpcParams},
+	rpc_params,
 	storage::StorageKey,
-	tx::{PairSigner, Payload, SubmittableExtrinsic, TxProgress},
+	tx::{PairSigner, SubmittableExtrinsic},
 	utils::AccountId32,
-	OnlineClient,
 };
-use tokio::sync::oneshot;
+use tokio::sync::RwLock;
+use tokio_retry::Retry;
+use tokio_stream::StreamExt;
+use tracing::{info, warn};
 
-use super::{Command, CommandSender, SendableCommand, WrappedProof, CELL_WITH_PROOF_SIZE};
-use crate::types::RuntimeVersion;
+use super::{Node, Nodes, Subscription, WrappedProof, CELL_WITH_PROOF_SIZE};
+use crate::{
+	consts::ExpectedNodeVariant,
+	types::{RetryConfig, RuntimeVersion, DEV_FLAG_GENHASH},
+};
 
 #[derive(Clone)]
-pub struct Client {
-	command_sender: CommandSender,
+struct RpcClient {
+	subxt_client: Arc<RwLock<(avail::Client, Node)>>,
+	nodes: Nodes,
+	genesis_hash: String,
+	retry_config: RetryConfig,
 }
 
-struct GetBlockHash {
-	block_number: u32,
-	response_sender: Option<oneshot::Sender<Result<H256>>>,
-}
+impl RpcClient {
+	pub async fn new(nodes: Nodes, genesis_hash: &str, retry_config: RetryConfig) -> Result<Self> {
+		// try and connect appropriate Node from the provided list
+		// will do retries with the provided Retry Config
+		let (client, node, _) = Retry::spawn(retry_config.iter(), || async {
+			Self::connect_nodes_until_success(
+				nodes.shuffle(Default::default()),
+				ExpectedNodeVariant::new(),
+				genesis_hash,
+				|_| futures::future::ok(()),
+			)
+			.await
+		})
+		.await?;
 
-#[async_trait]
-impl Command for GetBlockHash {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let hash = client
+		Ok(Self {
+			subxt_client: Arc::new(RwLock::new((client, node))),
+			genesis_hash: genesis_hash.to_string(),
+			nodes,
+			retry_config,
+		})
+	}
+
+	async fn create_subxt_client(
+		host: &str,
+		expected_node: ExpectedNodeVariant,
+		expected_genesis_hash: &str,
+	) -> Result<(avail::Client, Node)> {
+		let (client, _) = build_client(host, false).await.map_err(|e| eyre!(e))?;
+
+		// check genesis hash
+		let genesis_hash = client.genesis_hash();
+		info!("Genesis hash: {:?}", genesis_hash);
+		if let Some(cfg_genhash) = from_hex(expected_genesis_hash)
+			.ok()
+			.and_then(|e| TryInto::<[u8; 32]>::try_into(e).ok().map(H256::from))
+		{
+			if !genesis_hash.eq(&cfg_genhash) {
+				Err(eyre!(
+					"Genesis hash doesn't match the configured one! Change the config or the node url ({}).", host
+				))?
+			}
+		} else if expected_genesis_hash.starts_with(DEV_FLAG_GENHASH) {
+			warn!("Genesis hash configured for development ({}), skipping the genesis hash check entirely.", expected_genesis_hash);
+		} else {
+			Err(eyre!(
+				"Genesis hash invalid, badly configured or missing (\"{}\").",
+				expected_genesis_hash
+			))?
+		};
+
+		// check system and runtime versions
+		let system_version = client.rpc().system_version().await?;
+		let runtime_version: RuntimeVersion = client
 			.rpc()
-			.block_hash(Some(BlockNumber::from(self.block_number)))
-			.await?
-			.ok_or_else(|| eyre!("Block with number: {} not found", self.block_number))?;
+			.request("state_getRuntimeVersion", RpcParams::new())
+			.await?;
 
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(hash));
+		if !expected_node.matches(&system_version, &runtime_version.spec_name) {
+			return Err(eyre!(
+				"Expected Node system version:{}, found: {}. Skipping to another node.",
+				expected_node.system_version,
+				system_version.clone()
+			));
 		}
-		Ok(())
+
+		let variant = Node::new(
+			host.to_string(),
+			system_version,
+			runtime_version.spec_name,
+			runtime_version.spec_version,
+			&genesis_hash.to_string(),
+		);
+
+		Ok((client, variant))
 	}
 
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
+	async fn connect_nodes_until_success<T, Fun, Fut>(
+		nodes: Vec<Node>,
+		expected_node: ExpectedNodeVariant,
+		expected_genesis_hash: &str,
+		mut predicate: Fun,
+	) -> Result<(avail::Client, Node, T)>
+	where
+		Fun: FnMut(avail::Client) -> Fut + Copy,
+		Fut: std::future::Future<Output = Result<T>>,
+	{
+		// go through the provided list of Nodes to try and find and appropriate one,
+		// after a successful connection, try to execute passed call predicate
+		for Node { host, .. } in nodes.iter() {
+			let result = Self::create_subxt_client(
+				&host,
+				expected_node.clone(),
+				expected_genesis_hash.clone(),
+			)
+			.and_then(move |(client, node)| {
+				predicate(client.clone()).map_ok(|res| (client, node, res))
+			})
+			.await;
+
+			match result {
+				Err(error) => warn!(host, %error, "Skipping connection with this node"),
+				ok => return ok,
+			}
 		}
+
+		Err(eyre!("Failed to connect any appropriate working node"))
 	}
-}
 
-struct GetHeaderByHash {
-	block_hash: H256,
-	response_sender: Option<oneshot::Sender<Result<Header>>>,
-}
+	async fn with_retries<F, Fut, T>(&self, mut predicate: F) -> Result<T>
+	where
+		F: FnMut(avail::Client) -> Fut + Copy,
+		Fut: std::future::Future<Output = Result<T, subxt::error::Error>>,
+	{
+		// try and execute the passed function, use the Retry strategy if needed
+		if let Ok(result) = Retry::spawn(self.retry_config.iter(), move || async move {
+			predicate(self.current_client().await).await
+		})
+		.await
+		{
+			// this was successful, return early
+			return Ok(result);
+		}
 
-#[async_trait]
-impl Command for GetHeaderByHash {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let header = client
+		// if not, find another Node where this could still be done
+		let connected_node = self.connected_node().await;
+		let nodes = self.nodes.shuffle(connected_node.host);
+		let (client, node, result) = Self::connect_nodes_until_success(
+			nodes,
+			ExpectedNodeVariant::new(),
+			&connected_node.genesis_hash,
+			move |client| predicate(client).map_err(Report::from),
+		)
+		.await?;
+
+		// retries gave results, update currently connected Node and created Client
+		*self.subxt_client.write().await = (client, node);
+
+		Ok(result)
+	}
+
+	async fn create_subxt_subscriptions(
+		client: avail::Client,
+	) -> Result<impl Stream<Item = Result<Subscription, subxt::error::Error>>, subxt::error::Error>
+	{
+		// create Header subscription
+		let header_subscription = client.rpc().subscribe_finalized_block_headers().await?;
+		// map Header subscription to the same type for later matching
+		let headers = header_subscription.map_ok(|h| Subscription::Header(h));
+
+		let justification_subscription = client
 			.rpc()
-			.header(Some(self.block_hash))
+			.subscribe(
+				"grandpa_subscribeJustifications",
+				rpc_params![],
+				"grandpa_unsubscribeJustifications",
+			)
+			.await?;
+		// map Justification subscription to the same type for later matching
+		let justifications = justification_subscription.map_ok(|j| Subscription::Justification(j));
+
+		Ok(headers.merge(justifications))
+	}
+
+	async fn subscription_stream(self) -> impl Stream<Item = Result<Subscription>> {
+		async_stream::stream! {
+			'outer: loop{
+				let mut stream = match self.with_retries(|client| async move{
+					Self::create_subxt_subscriptions(client).await
+				}).await {
+					Ok(s) => s,
+					Err(err) => {
+						yield Err(err);
+						return;
+					}
+				};
+
+				loop {
+					// no more subscriptions left on stream, we have to return
+					let Some(result) = stream.next().await else { return};
+					// if Error was received, we need to switch to another RPC Client
+					let Ok(item) = result else { continue 'outer};
+					yield Ok(item);
+				}
+			}
+		}
+	}
+
+	async fn current_client(&self) -> avail::Client {
+		self.subxt_client.read().await.0.clone()
+	}
+
+	async fn connected_node(&self) -> Node {
+		self.subxt_client.read().await.1.clone()
+	}
+
+	pub async fn get_block_hash(&self, block_number: u32) -> Result<H256> {
+		let hash = self
+			.with_retries(|client| async move {
+				client
+					.rpc()
+					.block_hash(Some(BlockNumber::from(block_number)))
+					.await
+			})
 			.await?
-			.ok_or_else(|| eyre!("Block Header with hash: {:?} not found", self.block_hash))?;
+			.ok_or_else(|| eyre!("Block with number: {} not found", block_number))?;
 
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(header));
-		}
-		Ok(())
+		Ok(hash)
 	}
 
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
+	pub async fn get_header_by_hash(&self, block_hash: H256) -> Result<Header> {
+		let header = self
+			.with_retries(|client| async move { client.rpc().header(Some(block_hash)).await })
+			.await?
+			.ok_or_else(|| eyre!("Block Header with hash: {:?} not found", block_hash))?;
+
+		Ok(header)
 	}
-}
 
-struct GetValidatorSetByHash {
-	block_hash: H256,
-	response_sender: Option<oneshot::Sender<Result<Vec<Public>>>>,
-}
-
-#[async_trait]
-impl Command for GetValidatorSetByHash {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let res = client
-			.runtime_api()
-			.at(self.block_hash)
-			.call_raw::<Vec<(Public, u64)>>("GrandpaApi_grandpa_authorities", None)
+	pub async fn get_validator_set_by_hash(&self, block_hash: H256) -> Result<Vec<Public>> {
+		let res = self
+			.with_retries(|client| async move {
+				client
+					.runtime_api()
+					.at(block_hash)
+					.call_raw::<Vec<(Public, u64)>>("GrandpaApi_grandpa_authorities", None)
+					.await
+			})
 			.await?
 			.iter()
 			.map(|e| e.0)
 			.collect();
 
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-type KateRowsSender = oneshot::Sender<Result<Vec<Option<Vec<u8>>>>>;
-struct RequestKateRows {
-	rows: Vec<u32>,
-	block_hash: H256,
-	response_sender: Option<KateRowsSender>,
-}
-
-#[async_trait]
-impl Command for RequestKateRows {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let mut params = RpcParams::new();
-		params.push(self.rows.clone())?;
-		params.push(self.block_hash)?;
-
-		let res: Vec<Option<Vec<u8>>> = client.rpc().request("kate_queryRows", params).await?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-struct RequestKateProof {
-	positions: Vec<Position>,
-	block_hash: H256,
-	response_sender: Option<oneshot::Sender<Result<Vec<Cell>>>>,
-}
-
-#[async_trait]
-impl Command for RequestKateProof {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let mut params = RpcParams::new();
-		params.push(self.positions.clone())?;
-		params.push(self.block_hash)?;
-
-		let proofs: Vec<u8> = client.rpc().request("kate_queryProof", params).await?;
-
-		let i = proofs
-			.chunks_exact(CELL_WITH_PROOF_SIZE)
-			.map(|chunk| chunk.try_into().expect("chunks of 80 bytes size"));
-
-		let proof = self
-			.positions
-			.iter()
-			.zip(i)
-			.map(|(&position, &content)| Cell { position, content })
-			.collect::<Vec<_>>();
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(proof));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-struct GetSystemVersion {
-	response_sender: Option<oneshot::Sender<Result<String>>>,
-}
-
-#[async_trait]
-impl Command for GetSystemVersion {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let res = client.rpc().system_version().await?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-struct RequestRuntimeVersion {
-	response_sender: Option<oneshot::Sender<Result<RuntimeVersion>>>,
-}
-
-#[async_trait]
-impl Command for RequestRuntimeVersion {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let res: RuntimeVersion = client
-			.rpc()
-			.request("state_getRuntimeVersion", RpcParams::new())
-			.await?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-struct FetchSetIdAt {
-	block_hash: H256,
-	response_sender: Option<oneshot::Sender<Result<u64>>>,
-}
-
-#[async_trait]
-impl Command for FetchSetIdAt {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let set_id_key = api::storage().grandpa().current_set_id();
-		let res = client
-			.storage()
-			.at(self.block_hash)
-			.fetch(&set_id_key)
-			.await?
-			.ok_or_else(|| eyre!("The set_id should exist"))?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-struct GetValidatorSetAt {
-	block_hash: H256,
-	response_sender: Option<oneshot::Sender<Result<Option<Vec<AccountId32>>>>>,
-}
-
-#[async_trait]
-impl Command for GetValidatorSetAt {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		// get validator set from genesis (Substrate Account ID)
-		let validators_key = api::storage().session().validators();
-		let res = client
-			.storage()
-			.at(self.block_hash)
-			.fetch(&validators_key)
-			.await
-			.map_err(|e| eyre!(e))?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-type FromBytesSender = oneshot::Sender<Result<TxProgress<AvailConfig, OnlineClient<AvailConfig>>>>;
-struct SubmitFromBytesAndWatch {
-	tx_bytes: Vec<u8>,
-	response_sender: Option<FromBytesSender>,
-}
-
-#[async_trait]
-impl Command for SubmitFromBytesAndWatch {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let ext = SubmittableExtrinsic::from_bytes(client.clone(), self.tx_bytes.clone())
-			.submit_and_watch()
-			.await
-			.map_err(|e| eyre!(e))?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(ext));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-type SignedSender = oneshot::Sender<Result<TxProgress<AvailConfig, OnlineClient<AvailConfig>>>>;
-struct SubmitSignedAndWatch {
-	extrinsic: Payload<SubmitData>,
-	pair_signer: PairSigner<AvailConfig, Pair>,
-	params: AvailExtrinsicParams,
-	response_sender: Option<SignedSender>,
-}
-
-#[async_trait]
-impl Command for SubmitSignedAndWatch {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let res = client
-			.tx()
-			.sign_and_submit_then_watch(&self.extrinsic, &self.pair_signer, self.params.clone())
-			.await
-			.map_err(|e| eyre!(e))?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-struct GetPagedStorageKeys {
-	key: Vec<u8>,
-	count: u32,
-	start_key: Option<Vec<u8>>,
-	hash: Option<H256>,
-	response_sender: Option<oneshot::Sender<Result<Vec<StorageKey>>>>,
-}
-
-#[async_trait]
-impl Command for GetPagedStorageKeys {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let res = client
-			.rpc()
-			.storage_keys_paged(&self.key, self.count, self.start_key.as_deref(), self.hash)
-			.await
-			.map_err(|e| eyre!(e))?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-struct GetSessionKeyOwnerAt {
-	block_hash: H256,
-	public_key: ed25519::Public,
-	response_sender: Option<oneshot::Sender<Result<Option<AccountId32>>>>,
-}
-
-#[async_trait]
-impl Command for GetSessionKeyOwnerAt {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let session_key_key_owner = api::storage().session().key_owner(
-			KeyTypeId(sp_core::crypto::key_types::GRANDPA.0),
-			self.public_key.0,
-		);
-
-		let res = client
-			.storage()
-			.at(self.block_hash)
-			.fetch(&session_key_key_owner)
-			.await
-			.map_err(|e| eyre!(e))?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-struct RequestFinalityProof {
-	block_number: u32,
-	response_sender: Option<oneshot::Sender<Result<WrappedProof>>>,
-}
-
-#[async_trait]
-impl Command for RequestFinalityProof {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let mut params = RpcParams::new();
-		params.push(self.block_number)?;
-
-		let res: WrappedProof = client
-			.rpc()
-			.request("grandpa_proveFinality", params)
-			.await
-			.map_err(|e| eyre!("Request failed at Finality Proof. Error: {e}"))?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-struct GetGenesisHash {
-	response_sender: Option<oneshot::Sender<Result<H256>>>,
-}
-
-#[async_trait]
-impl Command for GetGenesisHash {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let res = client.genesis_hash();
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(res));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-struct GetFinalizedHeadHash {
-	response_sender: Option<oneshot::Sender<Result<H256>>>,
-}
-
-#[async_trait]
-impl Command for GetFinalizedHeadHash {
-	async fn run(&mut self, client: &avail_subxt::avail::Client) -> Result<()> {
-		let head = client.rpc().finalized_head().await?;
-
-		// send result back
-		// TODO: consider what to do if this results with None
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Ok(head));
-		}
-		Ok(())
-	}
-
-	fn abort(&mut self, error: Report) {
-		// TODO: consider what to do if this results with None
-		// TODO: maybe wrap error with specific error message per Command type implementation
-		if let Some(sender) = self.response_sender.take() {
-			_ = sender.send(Err(error));
-		}
-	}
-}
-
-// struct GetConnectedNode {
-// 	response_sender: oneshot::Sender<Result<Node>>,
-// }
-
-impl Client {
-	pub fn new(command_sender: CommandSender) -> Self {
-		Self { command_sender }
-	}
-
-	async fn execute_sync<F, T>(&self, command_with_sender: F) -> Result<T>
-	where
-		F: FnOnce(oneshot::Sender<Result<T>>) -> SendableCommand,
-	{
-		let (response_sender, response_receiver) = oneshot::channel();
-		let command = command_with_sender(response_sender);
-		self.command_sender.send(command).await?;
-		response_receiver
-			.await
-			.wrap_err("sender should not be dropped")?
-	}
-
-	pub async fn get_block_hash(&self, block_number: u32) -> Result<H256> {
-		self.execute_sync(|response_sender| {
-			Box::new(GetBlockHash {
-				block_number,
-				response_sender: Some(response_sender),
-			})
-		})
-		.await
-	}
-
-	pub async fn get_header_by_hash(&self, block_hash: H256) -> Result<Header> {
-		self.execute_sync(|response_sender| {
-			Box::new(GetHeaderByHash {
-				block_hash,
-				response_sender: Some(response_sender),
-			})
-		})
-		.await
-	}
-
-	pub async fn get_validator_set_by_hash(&self, block_hash: H256) -> Result<Vec<Public>> {
-		self.execute_sync(|response_sender| {
-			Box::new(GetValidatorSetByHash {
-				block_hash,
-				response_sender: Some(response_sender),
-			})
-		})
-		.await
+		Ok(res)
 	}
 
 	pub async fn get_finalized_head_hash(&self) -> Result<H256> {
-		self.execute_sync(|response_sender| {
-			Box::new(GetFinalizedHeadHash {
-				response_sender: Some(response_sender),
-			})
-		})
-		.await
+		let head = self
+			.with_retries(|client| async move { client.rpc().finalized_head().await })
+			.await?;
+
+		Ok(head)
 	}
 
 	pub async fn get_chain_head_header(&self) -> Result<Header> {
@@ -619,14 +294,18 @@ impl Client {
 		rows: Vec<u32>,
 		block_hash: H256,
 	) -> Result<Vec<Option<Vec<u8>>>> {
-		self.execute_sync(|response_sender| {
-			Box::new(RequestKateRows {
-				rows,
-				block_hash,
-				response_sender: Some(response_sender),
+		let mut params = RpcParams::new();
+		params.push(rows.clone())?;
+		params.push(block_hash)?;
+
+		let res: Vec<Option<Vec<u8>>> = self
+			.with_retries(|client| {
+				let params = params.clone();
+				async move { client.rpc().request("kate_queryRows", params).await }
 			})
-		})
-		.await
+			.await?;
+
+		Ok(res)
 	}
 
 	pub async fn request_kate_proof(
@@ -634,32 +313,49 @@ impl Client {
 		block_hash: H256,
 		positions: &[Position],
 	) -> Result<Vec<Cell>> {
-		self.execute_sync(|response_sender| {
-			Box::new(RequestKateProof {
-				positions: positions.into(),
-				block_hash,
-				response_sender: Some(response_sender),
+		let mut params = RpcParams::new();
+		params.push(positions.clone())?;
+		params.push(block_hash)?;
+
+		let proofs: Vec<u8> = self
+			.with_retries(|client| {
+				let params = params.clone();
+				async move { client.rpc().request("kate_queryProof", params).await }
 			})
-		})
-		.await
+			.await?;
+
+		let i = proofs
+			.chunks_exact(CELL_WITH_PROOF_SIZE)
+			.map(|chunk| chunk.try_into().expect("chunks of 80 bytes size"));
+
+		let proof = positions
+			.iter()
+			.zip(i)
+			.map(|(&position, &content)| Cell { position, content })
+			.collect::<Vec<_>>();
+
+		Ok(proof)
 	}
 
 	pub async fn get_system_version(&self) -> Result<String> {
-		self.execute_sync(|response_sender| {
-			Box::new(GetSystemVersion {
-				response_sender: Some(response_sender),
-			})
-		})
-		.await
+		let res = self
+			.with_retries(|client| async move { client.rpc().system_version().await })
+			.await?;
+
+		Ok(res)
 	}
 
 	pub async fn get_runtime_version(&self) -> Result<RuntimeVersion> {
-		self.execute_sync(|response_sender| {
-			Box::new(RequestRuntimeVersion {
-				response_sender: Some(response_sender),
+		let res: RuntimeVersion = self
+			.with_retries(|client| async move {
+				client
+					.rpc()
+					.request("state_getRuntimeVersion", RpcParams::new())
+					.await
 			})
-		})
-		.await
+			.await?;
+
+		Ok(res)
 	}
 
 	pub async fn get_validator_set_by_block_number(&self, block_num: u32) -> Result<Vec<Public>> {
@@ -668,13 +364,15 @@ impl Client {
 	}
 
 	pub async fn fetch_set_id_at(&self, block_hash: H256) -> Result<u64> {
-		self.execute_sync(|response_sender| {
-			Box::new(FetchSetIdAt {
-				block_hash,
-				response_sender: Some(response_sender),
+		let res = self
+			.with_retries(|client| {
+				let set_id_key = api::storage().grandpa().current_set_id();
+				async move { client.storage().at(block_hash).fetch(&set_id_key).await }
 			})
-		})
-		.await
+			.await?
+			.ok_or_else(|| eyre!("The set_id should exist"))?;
+
+		Ok(res)
 	}
 
 	pub async fn get_current_set_id_by_block_number(&self, block_num: u32) -> Result<u64> {
@@ -690,43 +388,56 @@ impl Client {
 	}
 
 	pub async fn get_validator_set_at(&self, block_hash: H256) -> Result<Option<Vec<AccountId32>>> {
-		self.execute_sync(|response_sender| {
-			Box::new(GetValidatorSetAt {
-				block_hash,
-				response_sender: Some(response_sender),
+		let res = self
+			.with_retries(|client| {
+				let validators_key = api::storage().session().validators();
+				async move { client.storage().at(block_hash).fetch(&validators_key).await }
 			})
-		})
-		.await
+			.await
+			.map_err(|e| eyre!(e))?;
+
+		Ok(res)
 	}
 
-	pub async fn submit_signed_and_watch(
+	pub async fn submit_signed_and_wait_for_finalized<Call: subxt::tx::TxPayload>(
 		&self,
-		extrinsic: Payload<SubmitData>,
-		pair_signer: PairSigner<AvailConfig, Pair>,
-		params: AvailExtrinsicParams,
-	) -> Result<TxProgress<AvailConfig, OnlineClient<AvailConfig>>> {
-		self.execute_sync(|response_sender| {
-			Box::new(SubmitSignedAndWatch {
-				extrinsic,
-				pair_signer,
-				params,
-				response_sender: Some(response_sender),
-			})
+		call: &Call,
+		signer: &PairSigner<AvailConfig, Pair>,
+		other_params: avail_subxt::primitives::AvailExtrinsicParams,
+	) -> Result<subxt::blocks::ExtrinsicEvents<AvailConfig>> {
+		self.with_retries(|client| {
+			let other_params = other_params.clone();
+			async move {
+				client
+					.tx()
+					.sign_and_submit_then_watch(call, signer, other_params)
+					.await?
+					.wait_for_finalized_success()
+					.await
+			}
 		})
 		.await
 	}
 
-	pub async fn submit_from_bytes_and_watch(
+	pub async fn submit_from_bytes_and_wait_for_finalized(
 		&self,
 		tx_bytes: Vec<u8>,
-	) -> Result<TxProgress<AvailConfig, OnlineClient<AvailConfig>>> {
-		self.execute_sync(|response_sender| {
-			Box::new(SubmitFromBytesAndWatch {
-				tx_bytes,
-				response_sender: Some(response_sender),
+	) -> Result<subxt::blocks::ExtrinsicEvents<AvailConfig>> {
+		let ext = self
+			.with_retries(|client| {
+				let tx_bytes = tx_bytes.clone();
+				async move {
+					SubmittableExtrinsic::from_bytes(client, tx_bytes)
+						.submit_and_watch()
+						.await?
+						.wait_for_finalized_success()
+						.await
+				}
 			})
-		})
-		.await
+			.await
+			.map_err(|e| eyre!(e))?;
+
+		Ok(ext)
 	}
 
 	pub async fn get_paged_storage_keys(
@@ -736,16 +447,21 @@ impl Client {
 		start_key: Option<Vec<u8>>,
 		hash: Option<H256>,
 	) -> Result<Vec<StorageKey>> {
-		self.execute_sync(|response_sender| {
-			Box::new(GetPagedStorageKeys {
-				key,
-				count,
-				start_key,
-				hash,
-				response_sender: Some(response_sender),
+		let res = self
+			.with_retries(|client| {
+				let key = &key;
+				let start_key = start_key.clone();
+				async move {
+					client
+						.rpc()
+						.storage_keys_paged(&key, count, start_key.as_deref(), hash)
+						.await
+				}
 			})
-		})
-		.await
+			.await
+			.map_err(|e| eyre!(e))?;
+
+		Ok(res)
 	}
 
 	pub async fn get_session_key_owner_at(
@@ -753,32 +469,44 @@ impl Client {
 		block_hash: H256,
 		public_key: ed25519::Public,
 	) -> Result<Option<AccountId32>> {
-		self.execute_sync(|response_sender| {
-			Box::new(GetSessionKeyOwnerAt {
-				block_hash,
-				public_key,
-				response_sender: Some(response_sender),
+		let res = self
+			.with_retries(|client| {
+				let session_key_key_owner = api::storage().session().key_owner(
+					KeyTypeId(sp_core::crypto::key_types::GRANDPA.0),
+					public_key.0,
+				);
+				async move {
+					client
+						.storage()
+						.at(block_hash)
+						.fetch(&session_key_key_owner)
+						.await
+				}
 			})
-		})
-		.await
+			.await
+			.map_err(|e| eyre!(e))?;
+
+		Ok(res)
 	}
 
 	pub async fn request_finality_proof(&self, block_number: u32) -> Result<WrappedProof> {
-		self.execute_sync(|response_sender| {
-			Box::new(RequestFinalityProof {
-				block_number,
-				response_sender: Some(response_sender),
+		let mut params = RpcParams::new();
+		params.push(block_number)?;
+
+		let res: WrappedProof = self
+			.with_retries(|client| {
+				let params = params.clone();
+				async move { client.rpc().request("grandpa_proveFinality", params).await }
 			})
-		})
-		.await
+			.await
+			.map_err(|e| eyre!("Request failed at Finality Proof. Error: {e}"))?;
+
+		Ok(res)
 	}
 
 	pub async fn get_genesis_hash(&self) -> Result<H256> {
-		self.execute_sync(|response_sender| {
-			Box::new(GetGenesisHash {
-				response_sender: Some(response_sender),
-			})
-		})
-		.await
+		let gen_hash = self.current_client().await.genesis_hash();
+
+		Ok(gen_hash)
 	}
 }

--- a/src/network/rpc/event_loop.rs
+++ b/src/network/rpc/event_loop.rs
@@ -377,10 +377,10 @@ impl EventLoop {
 	async fn handle_command(&self, mut command: SendableCommand) {
 		if let Err(err) = self
 			.rpc_client
-			.with_retries(|client| async move { command.run(&client).await })
+			.with_retries(move |client| async move { command.run(&client).await })
 			.await
 		{
-			command.abort(eyre!(err));
+			// command.abort(eyre!(err));
 		}
 	}
 

--- a/src/network/rpc/event_loop.rs
+++ b/src/network/rpc/event_loop.rs
@@ -113,9 +113,8 @@ impl EventLoop {
 
 	async fn connect_node(&mut self, expected: ExpectedNodeVariant) -> Result<()> {
 		// shuffle available Nodes list
-		self.nodes.reset();
 		// start connecting nodes from the config list
-		for Node { host, .. } in self.nodes.clone() {
+		for Node { host, .. } in self.nodes.shuffle() {
 			// retry connecting node with configured strategy
 			let retry_strategy = self.retry_config.clone().into_iter();
 			let res = Retry::spawn(retry_strategy, || async {
@@ -531,7 +530,9 @@ impl EventLoop {
 		self.subxt_client.replace(client);
 	}
 
-	fn store_node_data(&self, node: Node) -> Result<()> {
+	fn store_node_data(&mut self, node: Node) -> Result<()> {
+		// set the current host, so we can shuffle nodes properly, if needed
+		self.nodes.set_current_host(node.clone().host);
 		self.state.lock().unwrap().connected_node = node.clone();
 
 		info!("Genesis hash: {:?}", node.genesis_hash);

--- a/src/network/rpc/subscriptions.rs
+++ b/src/network/rpc/subscriptions.rs
@@ -95,7 +95,7 @@ impl SubscriptionLoop {
 		})
 	}
 
-	pub async fn run(&mut self) -> Result<()> {
+	pub async fn run(mut self) -> Result<()> {
 		// create subscriptions stream
 		let subscriptions = self.rpc_client.clone().subscription_stream().await;
 		futures::pin_mut!(subscriptions);

--- a/src/network/rpc/subscriptions.rs
+++ b/src/network/rpc/subscriptions.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use tokio::sync::broadcast::Sender;
 use tokio_stream::StreamExt;
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 use super::{Client, Subscription};
 use crate::{

--- a/src/types.rs
+++ b/src/types.rs
@@ -272,24 +272,21 @@ pub enum RetryConfig {
 	Fibonacci(FibonacciConfig),
 }
 
-impl IntoIterator for RetryConfig {
-	type Item = Duration;
-	type IntoIter = std::vec::IntoIter<Self::Item>;
-
-	fn into_iter(self) -> Self::IntoIter {
+impl RetryConfig {
+	pub fn iter(&self) -> Box<dyn Iterator<Item = Duration>> {
 		match self {
-			RetryConfig::Exponential(config) => ExponentialBackoff::from_millis(config.base)
-				.max_delay(Duration::from_millis(config.max_delay))
-				.map(jitter)
-				.take(config.retries)
-				.collect::<Vec<Duration>>()
-				.into_iter(),
-			RetryConfig::Fibonacci(config) => FibonacciBackoff::from_millis(config.base)
-				.max_delay(Duration::from_millis(config.max_delay))
-				.map(jitter)
-				.take(config.retries)
-				.collect::<Vec<Duration>>()
-				.into_iter(),
+			RetryConfig::Exponential(config) => Box::new(
+				ExponentialBackoff::from_millis(config.base)
+					.max_delay(Duration::from_millis(config.max_delay))
+					.map(jitter)
+					.take(config.retries),
+			),
+			RetryConfig::Fibonacci(config) => Box::new(
+				FibonacciBackoff::from_millis(config.base)
+					.max_delay(Duration::from_millis(config.max_delay))
+					.map(jitter)
+					.take(config.retries),
+			),
 		}
 	}
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -272,21 +272,24 @@ pub enum RetryConfig {
 	Fibonacci(FibonacciConfig),
 }
 
-impl RetryConfig {
-	pub fn iter(&self) -> Box<dyn Iterator<Item = Duration>> {
+impl IntoIterator for RetryConfig {
+	type Item = Duration;
+	type IntoIter = std::vec::IntoIter<Self::Item>;
+
+	fn into_iter(self) -> Self::IntoIter {
 		match self {
-			RetryConfig::Exponential(config) => Box::new(
-				ExponentialBackoff::from_millis(config.base)
-					.max_delay(Duration::from_millis(config.max_delay))
-					.map(jitter)
-					.take(config.retries),
-			),
-			RetryConfig::Fibonacci(config) => Box::new(
-				FibonacciBackoff::from_millis(config.base)
-					.max_delay(Duration::from_millis(config.max_delay))
-					.map(jitter)
-					.take(config.retries),
-			),
+			RetryConfig::Exponential(config) => ExponentialBackoff::from_millis(config.base)
+				.max_delay(Duration::from_millis(config.max_delay))
+				.map(jitter)
+				.take(config.retries)
+				.collect::<Vec<Duration>>()
+				.into_iter(),
+			RetryConfig::Fibonacci(config) => FibonacciBackoff::from_millis(config.base)
+				.max_delay(Duration::from_millis(config.max_delay))
+				.map(jitter)
+				.take(config.retries)
+				.collect::<Vec<Duration>>()
+				.into_iter(),
 		}
 	}
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -274,22 +274,22 @@ pub enum RetryConfig {
 
 impl IntoIterator for RetryConfig {
 	type Item = Duration;
-	type IntoIter = Box<dyn Iterator<Item = Duration> + Send>;
+	type IntoIter = std::vec::IntoIter<Self::Item>;
 
 	fn into_iter(self) -> Self::IntoIter {
 		match self {
-			RetryConfig::Exponential(config) => Box::new(
-				ExponentialBackoff::from_millis(config.base)
-					.max_delay(Duration::from_millis(config.max_delay))
-					.map(jitter)
-					.take(config.retries),
-			),
-			RetryConfig::Fibonacci(config) => Box::new(
-				FibonacciBackoff::from_millis(config.base)
-					.max_delay(Duration::from_millis(config.max_delay))
-					.map(jitter)
-					.take(config.retries),
-			),
+			RetryConfig::Exponential(config) => ExponentialBackoff::from_millis(config.base)
+				.max_delay(Duration::from_millis(config.max_delay))
+				.map(jitter)
+				.take(config.retries)
+				.collect::<Vec<Duration>>()
+				.into_iter(),
+			RetryConfig::Fibonacci(config) => FibonacciBackoff::from_millis(config.base)
+				.max_delay(Duration::from_millis(config.max_delay))
+				.map(jitter)
+				.take(config.retries)
+				.collect::<Vec<Duration>>()
+				.into_iter(),
 		}
 	}
 }


### PR DESCRIPTION
The new RPC Client supports multiple configurations for Retry strategies. If transient errors cannot be retried successfully, the RPC Client will switch to a new node and attempt the same call again. This process will be repeated until all available nodes are exhausted.