### PR TITLE
feat: add ping latency measurement.

### DIFF
--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -10,6 +10,7 @@ use libp2p::{
 	},
 	mdns,
 	multiaddr::Protocol,
+	ping,
 	swarm::{
 		dial_opts::{DialOpts, PeerCondition},
 		ConnectionError, SwarmEvent,
@@ -420,6 +421,13 @@ impl EventLoop {
 				Err(err) => {
 					trace!("Hole punching failed with: {remote_peer_id:#?}. Error: {err:#?}")
 				},
+			},
+			SwarmEvent::Behaviour(BehaviourEvent::Ping(ping::Event { result, .. })) => {
+				if let Ok(rtt) = result {
+					let _ = metrics
+						.record(MetricValue::PingLatency(rtt.as_millis() as f64))
+						.await;
+				}
 			},
 			SwarmEvent::Behaviour(BehaviourEvent::Upnp(event)) => match event {
 				upnp::Event::NewExternalAddr(addr) => {

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -70,6 +70,7 @@ pub enum MetricValue {
 	KadRoutingPeerNum(usize),
 	HealthCheck(),
 	BlockProcessingDelay(f64),
+	PingLatency(f64),
 	ReplicationFactor(u16),
 	QueryTimeout(u32),
 	#[cfg(feature = "crawl")]

--- a/src/telemetry/otlp.rs
+++ b/src/telemetry/otlp.rs
@@ -138,6 +138,9 @@ impl super::Metrics for Metrics {
 			super::MetricValue::QueryTimeout(number) => {
 				self.record_f64("query_timeout", number as f64).await?;
 			},
+			super::MetricValue::PingLatency(number) => {
+				self.record_f64("ping_latency", number).await?;
+			},
 			#[cfg(feature = "crawl")]
 			super::MetricValue::CrawlCellsSuccessRate(number) => {
 				self.record_f64("crawl_cells_success_rate", number).await?;


### PR DESCRIPTION
The following PR adds ping latency to the existing set of metrics on light client telemetry. This will enable us to accurately monitor and correlate round trip times for messages exchanged, with existing network traffic conditions.
