### PR TITLE
feat: use macos-14 for apple arm64 builds

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -51,7 +51,7 @@ jobs:
              path: target/aarch64-unknown-linux-gnu/maxperf/avail-light-linux-arm64.tar.gz
 
   binary_apple_arm64:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
           - uses: actions/checkout@v2
           - name: install cargo deps and build avail


### PR DESCRIPTION
* `macos-14` GitHub runners use `arm64` processors natively which should speed up these releases