### PR TITLE
feat: Adds trigger to build crawler externally

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -90,6 +90,19 @@ jobs:
               name: avail-light-apple-x86_64-binary
               path: target/maxperf/avail-light-apple-x86_64.tar.gz
 
+  build_crawler_external:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Trigger repository dispatch for crawler build
+        shell: bash
+        run: |
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
+            ${{ secrets.CRAWLER_BUILD_URL}} \
+            -d '{"event_type": "lc_crawler_build", "client_payload": {"tag": ${GITHUB_REF#refs/tags/}}}'
+
   # can extend binary publish 'needs' to include more releases i.e. arm64 in future
   binary_publish:
     needs: [binary_linux_amd64, binary_linux_aarch64, binary_apple_arm64, binary_apple_x86_64]


### PR DESCRIPTION
## Description
- [x] Adds actions to trigger crawler external build

## Related Issue

https://github.com/availproject/engineering/issues/468

## Motivation and Context
We need to automate Crawler builds externally for now.


