### PR TITLE
fix: Adds double quotes around tag env ref for json encoding

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -101,7 +101,7 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
             ${{ secrets.CRAWLER_BUILD_URL}} \
-            -d '{"event_type": "lc_crawler_build", "client_payload": {"tag": ${GITHUB_REF#refs/tags/}}}'
+            -d '{"event_type": "lc_crawler_build", "client_payload": {"tag": "${GITHUB_REF#refs/tags/}"}}'
 
   # can extend binary publish 'needs' to include more releases i.e. arm64 in future
   binary_publish:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -96,12 +96,13 @@ jobs:
       - name: Trigger repository dispatch for crawler build
         shell: bash
         run: |
-          curl \
+          curl -s -o /dev/null -w "%{http_code}" \
             -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
             ${{ secrets.CRAWLER_BUILD_URL}} \
-            -d '{"event_type": "lc_crawler_build", "client_payload": {"tag": "${GITHUB_REF#refs/tags/}"}}'
+            -d '{"event_type": "lc_crawler_build", "client_payload": {"tag": "${GITHUB_REF#refs/tags/}"}}' \
+            | grep -q "200"
 
   # can extend binary publish 'needs' to include more releases i.e. arm64 in future
   binary_publish:


### PR DESCRIPTION
## Description
- [x] Adds double quotes around tag env ref for json encoding
- [x] Adds repository event dispatch validation

## Related Issue

https://github.com/availproject/avail-light/actions/runs/8015887872/job/21896811564

## Motivation and Context
- External Crawler build failed due to a typo (missing double quotes) while building request payload

```json
Run curl \
{
  "message": "Problems parsing JSON",
  "documentation_url": "https://docs.github.com/rest/repos/repos#create-a-repository-dispatch-event"
}
```


