### PR TITLE
Improved p2p level logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "avail-light"
-version = "1.7.8"
+version = "1.8.0"
 dependencies = [
  "async-std",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light"
-version = "1.7.8"
+version = "1.8.0"
 authors = ["Avail Team"]
 default-run = "avail-light"
 edition = "2021"

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -380,7 +380,6 @@ mod tests {
 		mock_metrics.expect_count().returning(|_| ());
 		mock_metrics.expect_record().returning(|_| Ok(()));
 		mock_metrics.expect_set_multiaddress().returning(|_| ());
-		mock_metrics.expect_set_ip().returning(|_| ());
 		process_block(
 			&mock_client,
 			&mock_network_client,

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -13,6 +13,7 @@ use tokio::sync::{
 	mpsc::{self},
 	oneshot,
 };
+use tracing::info;
 
 #[cfg(feature = "network-analysis")]
 pub mod analyzer;
@@ -161,6 +162,8 @@ fn build_swarm(
 				.with_per_connection_event_buffer_size(cfg.per_connection_event_buffer_size)
 		})
 		.build();
+
+	info!("Local peerID: {}", swarm.local_peer_id());
 
 	// Setting the mode this way disables automatic mode changes.
 	//

--- a/src/network/p2p/client.rs
+++ b/src/network/p2p/client.rs
@@ -353,7 +353,6 @@ impl Command for GetMultiaddress {
 		let last_address = entries
 			.swarm()
 			.external_addresses()
-			.into_iter()
 			.cloned()
 			.collect::<Vec<_>>();
 

--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -404,20 +404,17 @@ impl EventLoop {
 			},
 			SwarmEvent::Behaviour(BehaviourEvent::AutoNat(event)) => match event {
 				autonat::Event::InboundProbe(e) => {
-					trace!("AutoNat Inbound Probe: {:#?}", e);
+					trace!("[AutoNat] Inbound Probe: {:#?}", e);
 				},
 				autonat::Event::OutboundProbe(e) => {
-					trace!("AutoNat Outbound Probe: {:#?}", e);
+					trace!("[AutoNat] Outbound Probe: {:#?}", e);
 				},
 				autonat::Event::StatusChanged { old, new } => {
-					debug!(
-						"AutoNat Old status: {:#?}. AutoNat New status: {:#?}",
-						old, new
-					);
+					debug!("[AutoNat] Old status: {:#?}. New status: {:#?}", old, new);
 					// check if went private or are private
 					// if so, create reservation request with relay
 					if new == NatStatus::Private || old == NatStatus::Private {
-						info!("Autonat says we're still private.");
+						info!("[AutoNat] Autonat says we're still private.");
 						// Fat clients should always be in Kademlia client mode, no need to do NAT traversal
 						if !self.event_loop_config.is_fat_client {
 							// select a relay, try to dial it
@@ -447,16 +444,16 @@ impl EventLoop {
 			},
 			SwarmEvent::Behaviour(BehaviourEvent::Upnp(event)) => match event {
 				upnp::Event::NewExternalAddr(addr) => {
-					info!("New external address: {addr}");
+					trace!("[UPnP] New external address: {addr}");
 				},
 				upnp::Event::GatewayNotFound => {
-					trace!("Gateway does not support UPnP");
+					trace!("[UPnP] Gateway does not support UPnP");
 				},
 				upnp::Event::NonRoutableGateway => {
-					trace!("Gateway is not exposed directly to the public Internet, i.e. it itself has a private IP address.");
+					trace!("[UPnP] Gateway is not exposed directly to the public Internet, i.e. it itself has a private IP address.");
 				},
 				upnp::Event::ExpiredExternalAddr(addr) => {
-					trace!("Gateway address expired: {addr}");
+					trace!("[UPnP] Gateway address expired: {addr}");
 				},
 			},
 			swarm_event => {
@@ -483,6 +480,12 @@ impl EventLoop {
 					},
 					SwarmEvent::IncomingConnectionError { .. } => {
 						metrics.count(MetricCounter::IncomingConnectionError).await;
+					},
+					SwarmEvent::ExternalAddrConfirmed { address } => {
+						info!(
+							"External reachability confirmed on address: {}",
+							address.to_string()
+						);
 					},
 					SwarmEvent::ConnectionEstablished { peer_id, .. } => {
 						metrics.count(MetricCounter::ConnectionEstablished).await;

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -67,7 +67,7 @@ pub enum MetricValue {
 	RPCCallDuration(f64),
 	DHTPutDuration(f64),
 	DHTPutSuccess(f64),
-	KadRoutingPeerNum(usize),
+	ConnectedPeersNum(usize),
 	HealthCheck(),
 	BlockProcessingDelay(f64),
 	PingLatency(f64),
@@ -87,5 +87,4 @@ pub trait Metrics {
 	async fn count(&self, counter: MetricCounter);
 	async fn record(&self, value: MetricValue) -> Result<()>;
 	async fn set_multiaddress(&self, multiaddr: String);
-	async fn set_ip(&self, ip: String);
 }

--- a/src/telemetry/otlp.rs
+++ b/src/telemetry/otlp.rs
@@ -11,7 +11,7 @@ use tokio::sync::RwLock;
 
 use super::MetricCounter;
 
-const ATTRIBUTE_NUMBER: usize = 9;
+const ATTRIBUTE_NUMBER: usize = 8;
 
 #[derive(Debug)]
 pub struct Metrics {
@@ -43,7 +43,6 @@ impl Metrics {
 				"multiaddress",
 				self.attributes.multiaddress.read().await.clone(),
 			),
-			KeyValue::new("ip", self.attributes.ip.read().await.clone()),
 			KeyValue::new("avail_address", self.attributes.avail_address.clone()),
 			KeyValue::new("partition_size", self.attributes.partition_size.clone()),
 			KeyValue::new("operating_mode", self.attributes.operating_mode.clone()),
@@ -73,11 +72,6 @@ impl Metrics {
 	async fn set_multiaddress(&self, multiaddr: String) {
 		let mut m = self.attributes.multiaddress.write().await;
 		*m = multiaddr;
-	}
-
-	async fn set_ip(&self, ip: String) {
-		let mut i = self.attributes.ip.write().await;
-		*i = ip;
 	}
 }
 
@@ -122,8 +116,8 @@ impl super::Metrics for Metrics {
 			super::MetricValue::DHTPutSuccess(number) => {
 				self.record_f64("dht_put_success", number).await?;
 			},
-			super::MetricValue::KadRoutingPeerNum(number) => {
-				self.record_u64("kad_routing_table_peer_num", number as u64)
+			super::MetricValue::ConnectedPeersNum(number) => {
+				self.record_u64("connected_peers_num", number as u64)
 					.await?;
 			},
 			super::MetricValue::HealthCheck() => {
@@ -159,10 +153,6 @@ impl super::Metrics for Metrics {
 
 	async fn set_multiaddress(&self, multiaddr: String) {
 		self.set_multiaddress(multiaddr).await;
-	}
-
-	async fn set_ip(&self, ip: String) {
-		self.set_ip(ip).await;
 	}
 }
 


### PR DESCRIPTION
- Added `info` level logs for external address confirmations, local peerID and the number of connected peers
- Connected peer number is a snapshot of all of the connected peers at the time of check. It's number is dependent on the `connection_idle_timeout` parameter, and its low numbers are not indicative of connectivity issues
- Added `debug` level log with a list of all of the connected peers with their peerIDs
- Renamed `kad_routing_table_peer_num` to `connected_peers_num`. Changed the way its retrieved, we now use the `NetworkInfo` structure from libp2p
- Removed the `ip` attribute from OTel