### PR TITLE
feat: use macos-13 runner for apple x64 builds

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -72,7 +72,7 @@ jobs:
               path: target/maxperf/avail-light-apple-arm64.tar.gz
 
   binary_apple_x86_64:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
           - uses: actions/checkout@v2
           - name: install cargo deps and build avail


### PR DESCRIPTION
* the `macos-13` runner uses a later version of MacOS (12 -> 13) and has an extra core which should speed up builds