### PR TITLE
Fix: Slow shutdown sequence for WSL

### DIFF
--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -20,6 +20,7 @@ use libp2p::{
 use rand::seq::SliceRandom;
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 use tokio::{
+	signal::ctrl_c,
 	sync::oneshot,
 	time::{interval_at, Instant, Interval},
 };
@@ -173,6 +174,10 @@ impl EventLoop {
 				// break the loop immediately, proceed to the cleanup phase
 				_ = self.shutdown.triggered_shutdown() => {
 					info!("Shutdown triggered, exiting the network event loop");
+					break;
+				}
+				_ = ctrl_c() => {
+					info!("SIGINT triggered, exiting the network event loop");
 					break;
 				}
 			}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-	// collections::HashMap,
-	fmt::{self, Display, Formatter},
-};
+use std::fmt::{self, Display, Formatter};
 
 use async_trait::async_trait;
 use color_eyre::Result;


### PR DESCRIPTION
Currently the shutdown sequence on WSL is extremely slow when users hit ctrl + c. The following PR enables a temporary fix for faster shutdown of the binary in WSL bypassing original shutdown sequence. 

Please refer to [this thread](https://availproject.slack.com/archives/C06QH2NCMFH/p1712195587883699?thread_ts=1712166320.721069&cid=C06QH2NCMFH) for more context.