### PR TITLE
Remove multiaddress from metrics

### DIFF
--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -100,7 +100,10 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 	let version = clap::crate_version!();
 	info!("Running Avail light client version: {version}. Role: {client_role}.");
 	info!("Using config: {cfg:?}");
-	info!("Avail address is: {}", &identity_cfg.avail_address);
+	info!(
+		"Avail ss58 address: {}, public key: {}",
+		&identity_cfg.avail_address, &identity_cfg.avail_public_key
+	);
 
 	if let Some(error) = parse_error {
 		warn!("Using default log level: {}", error);
@@ -126,7 +129,7 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 		peer_id,
 		ip: RwLock::new("".to_string()),
 		origin: cfg.origin.clone(),
-		avail_address: identity_cfg.avail_address.clone(),
+		avail_address: identity_cfg.avail_public_key.clone(),
 		operating_mode: cfg.operation_mode.to_string(),
 		partition_size: cfg
 			.block_matrix_partition

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -125,7 +125,6 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 		role: client_role.into(),
 		peer_id,
 		ip: RwLock::new("".to_string()),
-		multiaddress: RwLock::new("".to_string()), // Default value is empty until first processed block triggers an update,
 		origin: cfg.origin.clone(),
 		avail_address: identity_cfg.avail_address.clone(),
 		operating_mode: cfg.operation_mode.to_string(),

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -10,7 +10,7 @@ use avail_light::{
 	shutdown::Controller,
 	sync_client::SyncClient,
 	sync_finality::SyncFinality,
-	telemetry::{self, otlp::MetricAttributes},
+	telemetry::{self, otlp::MetricAttributes, MetricValue, Metrics},
 	types::{CliOpts, IdentityConfig, LibP2PConfig, RuntimeConfig, State},
 };
 use clap::Parser;
@@ -239,6 +239,7 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 			result
 		},
 	)));
+	ot_metrics.record(MetricValue::HealthCheck()).await?;
 
 	info!("Waiting for first finalized header...");
 	let block_header = match shutdown

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -353,7 +353,6 @@ mod tests {
 		let mut mock_metrics = telemetry::MockMetrics::new();
 		mock_metrics.expect_count().returning(|_| ());
 		mock_metrics.expect_record().returning(|_| Ok(()));
-		mock_metrics.expect_set_multiaddress().returning(|_| ());
 		process_block(
 			db,
 			&mock_network_client,

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -42,16 +42,6 @@ pub async fn process_block(
 		.await
 		.wrap_err("Unable to get Kademlia map size")?;
 
-	// Get last confirmed external multiaddress
-	if let Ok(multiaddrs) = p2p_client.get_multiaddress_and_ip().await {
-		debug!("Confirmed external multiaddresses: {:?}", multiaddrs);
-		if let Some(last_confirmed_ma) = multiaddrs.last() {
-			metrics
-				.set_multiaddress(last_confirmed_ma.to_string())
-				.await;
-		}
-	}
-
 	let peers_num = p2p_client.count_dht_entries().await?;
 	info!("Number of connected peers: {peers_num}");
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -86,5 +86,4 @@ pub enum MetricValue {
 pub trait Metrics {
 	async fn count(&self, counter: MetricCounter);
 	async fn record(&self, value: MetricValue) -> Result<()>;
-	async fn set_multiaddress(&self, multiaddr: String);
 }

--- a/src/telemetry/otlp.rs
+++ b/src/telemetry/otlp.rs
@@ -11,7 +11,7 @@ use tokio::sync::RwLock;
 
 use super::MetricCounter;
 
-const ATTRIBUTE_NUMBER: usize = 8;
+const ATTRIBUTE_NUMBER: usize = 7;
 
 #[derive(Debug)]
 pub struct Metrics {
@@ -25,7 +25,6 @@ pub struct MetricAttributes {
 	pub role: String,
 	pub peer_id: String,
 	pub ip: RwLock<String>,
-	pub multiaddress: RwLock<String>,
 	pub origin: String,
 	pub avail_address: String,
 	pub operating_mode: String,
@@ -39,10 +38,6 @@ impl Metrics {
 			KeyValue::new("role", self.attributes.role.clone()),
 			KeyValue::new("origin", self.attributes.origin.clone()),
 			KeyValue::new("peerID", self.attributes.peer_id.clone()),
-			KeyValue::new(
-				"multiaddress",
-				self.attributes.multiaddress.read().await.clone(),
-			),
 			KeyValue::new("avail_address", self.attributes.avail_address.clone()),
 			KeyValue::new("partition_size", self.attributes.partition_size.clone()),
 			KeyValue::new("operating_mode", self.attributes.operating_mode.clone()),
@@ -67,11 +62,6 @@ impl Metrics {
 				observer.observe_f64(&instrument, value, &attributes)
 			})?;
 		Ok(())
-	}
-
-	async fn set_multiaddress(&self, multiaddr: String) {
-		let mut m = self.attributes.multiaddress.write().await;
-		*m = multiaddr;
 	}
 }
 
@@ -149,10 +139,6 @@ impl super::Metrics for Metrics {
 			},
 		};
 		Ok(())
-	}
-
-	async fn set_multiaddress(&self, multiaddr: String) {
-		self.set_multiaddress(multiaddr).await;
 	}
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -975,6 +975,8 @@ pub struct IdentityConfig {
 	pub avail_key_pair: Keypair,
 	/// Avail ss58 address
 	pub avail_address: String,
+	/// Avail public key
+	pub avail_public_key: String,
 }
 
 impl IdentityConfig {
@@ -1000,13 +1002,16 @@ impl IdentityConfig {
 		if let Some(password) = password {
 			suri.password = Some(SecretString::from_str(password)?);
 		}
+
 		let avail_key_pair = Keypair::from_uri(&suri)?;
 		let avail_address = avail_key_pair.public_key().to_account_id();
 		let avail_address = sp_core::crypto::AccountId32::from(avail_address.0).to_ss58check();
+		let avail_public_key = hex::encode(avail_key_pair.public_key());
 
 		Ok(IdentityConfig {
 			avail_key_pair,
 			avail_address,
+			avail_public_key,
 		})
 	}
 }


### PR DESCRIPTION
Main aim of this PR is to remove multiaddress from the metrics attributes, and introduce changes from goldberg:
- Add avail public key in hex format to logs
- ~~Send IP as metrics attribute~~
- Invoke health check metric before processing first block