### PR TITLE
Replace records_iter with records call from trait.

### DIFF
--- a/src/network/p2p/kad_mem_store.rs
+++ b/src/network/p2p/kad_mem_store.rs
@@ -103,11 +103,6 @@ impl MemoryStore {
 		RecordStore::put(self, r)
 	}
 
-	// Return an iterator over records
-	pub fn records_iter(&mut self) -> std::collections::hash_map::Iter<'_, RecordKey, Record> {
-		self.records.iter()
-	}
-
 	/// Shrinks the capacity of hashmap as much as possible
 	pub fn shrink_hashmap(&mut self) {
 		self.records.shrink_to_fit();


### PR DESCRIPTION
This PR replaces obsolete `records_iter` function with `records` function of `RecordStore` trait.