### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ avail_secret_seed_phrase = "bottom drive obey lake curtain smoke basket hold rac
   - `info`
   - `warn`
   - `error`
-- `--avail-passphrase <PASSPHRASE>`: Avail secret seed phrase password, flag is optional, overrides passoword from identity file
+- `--avail-passphrase <PASSPHRASE>`: Avail secret seed phrase password, flag is optional, overrides password from identity file
 - `--seed`: Seed string for libp2p keypair generation
 - `--secret-key`: Ed25519 private key for libp2p keypair generation
 


### PR DESCRIPTION
Fix typos in README.md.
`passoword` => `password`