### PR TITLE
Move providers to separate module.

### DIFF
--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -19,11 +19,13 @@ use tracing::info;
 pub mod analyzer;
 mod client;
 mod event_loop;
+mod kad_mem_providers;
 mod kad_mem_store;
 
 use crate::types::{LibP2PConfig, SecretKey};
 pub use client::Client;
 pub use event_loop::EventLoop;
+pub use kad_mem_providers::ProvidersConfig;
 pub use kad_mem_store::MemoryStoreConfig;
 
 use self::{client::BlockStat, kad_mem_store::MemoryStore};

--- a/src/network/p2p/kad_mem_providers.rs
+++ b/src/network/p2p/kad_mem_providers.rs
@@ -1,0 +1,129 @@
+use libp2p::identity::PeerId;
+use libp2p::kad::store::{Error, Result};
+use libp2p::kad::{KBucketKey, ProviderRecord, RecordKey, K_VALUE};
+use smallvec::SmallVec;
+use std::borrow::Cow;
+use std::collections::{hash_map, hash_set, HashMap, HashSet};
+use std::iter;
+
+#[derive(Clone, Debug)]
+pub struct ProvidersConfig {
+	/// The maximum number of providers stored for a key.
+	///
+	/// This should match up with the chosen replication factor.
+	pub max_providers_per_key: usize,
+	/// The maximum number of provider records for which the
+	/// local node is the provider.
+	pub max_provided_keys: usize,
+}
+
+impl Default for ProvidersConfig {
+	// Default values kept in line with libp2p
+	fn default() -> Self {
+		Self {
+			max_provided_keys: 1024,
+			max_providers_per_key: K_VALUE.get(),
+		}
+	}
+}
+
+pub struct Providers {
+	/// Providers configuration
+	config: ProvidersConfig,
+	/// The stored provider records.
+	providers: HashMap<RecordKey, SmallVec<[ProviderRecord; K_VALUE.get()]>>,
+	/// The set of all provider records for the node identified by `local_key`.
+	/// Must be kept in sync with `providers`.
+	provided: HashSet<ProviderRecord>,
+}
+
+pub type ProviderIter<'a> = iter::Map<
+	hash_set::Iter<'a, ProviderRecord>,
+	fn(&'a ProviderRecord) -> Cow<'a, ProviderRecord>,
+>;
+
+impl Providers {
+	pub fn with_config(config: ProvidersConfig) -> Self {
+		Providers {
+			config,
+			providers: Default::default(),
+			provided: Default::default(),
+		}
+	}
+
+	pub fn add_provider(
+		&mut self,
+		local_key: KBucketKey<PeerId>,
+		record: ProviderRecord,
+	) -> Result<()> {
+		let num_keys = self.providers.len();
+
+		// Obtain the entry
+		let providers = match self.providers.entry(record.key.clone()) {
+			e @ hash_map::Entry::Occupied(_) => e,
+			e @ hash_map::Entry::Vacant(_) => {
+				if self.config.max_provided_keys == num_keys {
+					return Err(Error::MaxProvidedKeys);
+				}
+				e
+			},
+		}
+		.or_insert_with(Default::default);
+
+		if let Some(i) = providers.iter().position(|p| p.provider == record.provider) {
+			// In-place update of an existing provider record.
+			providers.as_mut()[i] = record;
+		} else {
+			// It is a new provider record for that key.
+			let key = KBucketKey::new(record.key.clone());
+			let provider = KBucketKey::from(record.provider);
+			if let Some(i) = providers.iter().position(|p| {
+				let pk = KBucketKey::from(p.provider);
+				provider.distance(&key) < pk.distance(&key)
+			}) {
+				// Insert the new provider.
+				if local_key.preimage() == &record.provider {
+					self.provided.insert(record.clone());
+				}
+				providers.insert(i, record);
+				// Remove the excess provider, if any.
+				if providers.len() > self.config.max_providers_per_key {
+					if let Some(p) = providers.pop() {
+						self.provided.remove(&p);
+					}
+				}
+			} else if providers.len() < self.config.max_providers_per_key {
+				// The distance of the new provider to the key is larger than
+				// the distance of any existing provider, but there is still room.
+				if local_key.preimage() == &record.provider {
+					self.provided.insert(record.clone());
+				}
+				providers.push(record);
+			}
+		}
+		Ok(())
+	}
+
+	pub fn providers(&self, key: &RecordKey) -> Vec<ProviderRecord> {
+		self.providers
+			.get(key)
+			.map_or_else(Vec::new, |ps| ps.clone().into_vec())
+	}
+
+	pub fn provided(&self) -> ProviderIter<'_> {
+		self.provided.iter().map(Cow::Borrowed)
+	}
+
+	pub fn remove_provider(&mut self, key: &RecordKey, provider: &PeerId) {
+		if let hash_map::Entry::Occupied(mut e) = self.providers.entry(key.clone()) {
+			let providers = e.get_mut();
+			if let Some(i) = providers.iter().position(|p| &p.provider == provider) {
+				let p = providers.remove(i);
+				self.provided.remove(&p);
+			}
+			if providers.is_empty() {
+				e.remove();
+			}
+		}
+	}
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,5 @@
 //! Shared light client structs and enums.
-
-use crate::network::p2p::MemoryStoreConfig;
+use crate::network::p2p::{MemoryStoreConfig, ProvidersConfig};
 use crate::network::rpc::{Event, Node as RpcNode};
 use crate::utils::{extract_app_lookup, extract_kate};
 use avail_core::DataLookup;
@@ -606,8 +605,10 @@ impl From<&LibP2PConfig> for MemoryStoreConfig {
 		MemoryStoreConfig {
 			max_records: cfg.kademlia.max_kad_record_number, // ~2hrs
 			max_value_bytes: cfg.kademlia.max_kad_record_size + 1,
-			max_providers_per_key: usize::from(cfg.kademlia.record_replication_factor), // Needs to match the replication factor, per libp2p docs
-			max_provided_keys: cfg.kademlia.max_kad_provided_keys,
+			providers: ProvidersConfig {
+				max_providers_per_key: usize::from(cfg.kademlia.record_replication_factor), // Needs to match the replication factor, per libp2p docs
+				max_provided_keys: cfg.kademlia.max_kad_provided_keys,
+			},
 		}
 	}
 }


### PR DESCRIPTION
This PR moves provider related code in Kademlia memory store into separate module. Idea is to reuse in-memory providers implementation in future RocksDB store implementation. Also this abstracts away providers related code from Kademlia memory store.