### PR TITLE
Support incomplete (empty or failed) blocks on the v2 API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.9.0
+
+- Introduce `incomplete` block status for blocks without data transactions or for blocks lacking commitments due to a failure
+
 ## [v1.8.1](https://github.com/availproject/avail-light/releases/tag/v1.8.1) - 2024-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "avail-light"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-std",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light"
-version = "1.8.0"
+version = "1.9.0"
 authors = ["Avail Team"]
 default-run = "avail-light"
 edition = "2021"

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -56,7 +56,12 @@ impl<T: Database + Clone + Send + Sync + 'static> Server<T> {
 			..
 		} = self.cfg.clone();
 
-		let v1_api = v1::routes(self.db.clone(), app_id, self.state.clone());
+		let v1_api = v1::routes(
+			self.db.clone(),
+			app_id,
+			self.state.clone(),
+			self.cfg.clone(),
+		);
 		let v2_api = v2::routes(
 			self.version.clone(),
 			self.network_version.clone(),

--- a/src/api/v2/README.md
+++ b/src/api/v2/README.md
@@ -84,6 +84,9 @@ Content-Type: application/json
 - **app_data** - range of blocks with app data retrieved and verified
 - **historical_sync** - state for historical blocks syncing up to configured block (omitted if historical sync is not configured)
 
+Blocks without data transactions, or blocks that fails to commit to the data, are considered incomplete and commitments will be empty.
+Ranges of **available** and **app_data** blocks can contain **incomplete** blocks.
+
 ### Historical sync
 
 - **synced** - `true` if there are no historical blocks left to sync
@@ -101,7 +104,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "status": "unavailable|pending|verifying-header|verifying-confidence|verifying-data|finished",
+  "status": "unavailable|pending|verifying-header|verifying-confidence|verifying-data|incomplete|finished",
   "confidence": {confidence} // Optional
 }
 ```
@@ -120,6 +123,7 @@ Content-Type: application/json
 - **verifying-header** - block processing is started, and the header finality is being checked
 - **verifying-confidence** - block header is verified and available, confidence is being checked
 - **verifying-data** - confidence is achieved, and data is being fetched and verified (if configured)
+- **incomplete** - block header is available, but data availability cannot be verified
 - **finished** - block header is available, confidence is achieved, and data is available (if configured)
 
 This status does not give information on what is available. In the case of web sockets messages are already pushed, similar to case of the frequent polling, so header and confidence will be available if **verifying-header** and **verifying-confidence** has been successful.
@@ -134,7 +138,7 @@ HTTP/1.1 404 Not Found
 
 Gets the block header if it is available.
 
-If **block_status = "verifying-confidence|verifying-data|finished"**, the header is available, and the response is:
+If **block_status = "verifying-confidence|verifying-data|incomplete|finished"**, the header is available, and the response is:
 
 ```yaml
 HTTP/1.1 200 OK


### PR DESCRIPTION
This PR handles incomplete block status as specified in https://www.notion.so/avail-project/RFC-206-Empty-or-failed-block-representation-ed690b6ba67a414caf7a1005b3265216, and contains following changes:
- Version is increased to 1.9.0
- New `incomplete` block status is introduced when there are no data transactions in the block (or block build is failed)
- Special case is added for `/v1/confidence` API to return configured confidence for incomplete blocks. That will ensure that v2 API is not affected when v1 is removed
