### PR TITLE
Disable building broken arm64 container image in release action

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -174,7 +174,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile.release
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: availj/avail-light:${{ steps.prepare.outputs.tag_name }}
           build-args: |


### PR DESCRIPTION
This is a makeshift fix for #552.

As explained in the issue, the arm64 seems to be unusable as it attempts to run arm64 `avail-light` on amd64 ubuntu. 

I've had a look at https://github.com/availproject/avail/blob/main/.github/workflows/releaser_docker.yml#L43 and it seems that avail does not distribute arm64 images. This is fine since amd64 images run fine on macs. 

Please see #552 for more details.