### PR TITLE
Support better naming for secret URI parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.9.0
 
+- Deprecate `--avail-passphrase` CLI parameter and `avail_secret_seed_phrase` configuration parameter and introduce `--avail-suri` and `avail_secret_uri` alternatives.
 - Introduce `incomplete` block status for blocks without data transactions or for blocks lacking commitments due to a failure
 
 ## [v1.8.1](https://github.com/availproject/avail-light/releases/tag/v1.8.1) - 2024-04-26

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ avail_secret_seed_phrase = "bottom drive obey lake curtain smoke basket hold rac
   - `info`
   - `warn`
   - `error`
-- `--avail-passphrase <PASSPHRASE>`: Avail secret seed phrase password, flag is optional, overrides password from identity file
+- `--avail-suri <SECRET_URI>`: Avail secret URI, flag is optional, overrides secret URI from identity file
+- `--avail-passphrase <PASSPHRASE>`: (DEPRECATED) Avail secret seed phrase password, flag is optional, overrides password from identity file
 - `--seed`: Seed string for libp2p keypair generation
 - `--secret-key`: Ed25519 private key for libp2p keypair generation
 
@@ -141,7 +142,7 @@ avail_secret_seed_phrase = "bottom drive obey lake curtain smoke basket hold rac
 
 ## Identity
 
-In the Avail network, a light client's identity can be configured using the `identity.toml` file. If not specified, a secret seed phrase will be generated and stored in the identity file when the light client starts. To use an existing seed phrase, set the `avail_secret_seed_phrase` entry in the `identity.toml` file. Seed phrase will be used to derive Sr25519 key pair for signing. Location of the identity file can be specified using `--identity` option.
+In the Avail network, a light client's identity can be configured using the `identity.toml` file. If not specified, a secret URI will be generated and stored in the identity file when the light client starts. To use an existing secret URI, set the `avail_secret_uri` entry in the `identity.toml` file. Secret URI will be used to derive Sr25519 key pair for signing. Location of the identity file can be specified using `--identity` option. Parameter `avail_secret_seed_phrase` is deprecated and replaced with `avail_secret_uri`. More info can be found on [Substrate URI documentation](https://polkadot.js.org/docs/keyring/start/suri/).
 
 ## Configuration reference
 

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -87,8 +87,14 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 			.expect("global default subscriber is set")
 	}
 
-	let identity_cfg =
-		IdentityConfig::load_or_init(&opts.identity, opts.avail_passphrase.as_deref())?;
+	if opts.avail_passphrase.is_some() {
+		warn!("Using deprecated CLI parameter `--avail-passphrase`, use `--avail-suri` instead.");
+	}
+
+	let identity_cfg = IdentityConfig::load_or_init(
+		&opts.identity,
+		opts.avail_suri.or(opts.avail_passphrase).as_deref(),
+	)?;
 	info!("Identity loaded from {}", &opts.identity);
 
 	let client_role = if cfg.is_fat_client() {


### PR DESCRIPTION
This PR introduces better naming for secret URI CLI and configuration parameters. This parameter is highly coupled to the end user configuration and we should consider if we need to implement some transitioning process. 

Options are:
- we can emit metric event when LC is started with old parameter
- we can rename parameter in the end user config file on LC run
- we can warn user if deprecated CLI parameter is used

Other options are welcomed.