### PR TITLE
Enable manual trigger of the default github workflow.

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - develop
+  workflow_dispatch:
 
 jobs:
   build_and_test:


### PR DESCRIPTION
This PR should enable manual triggering of the github workflow on some specific branch or commit, without creating PR. Primary intention is to test branches which will not end up merged into the main branch (e.g. goldberg versions of the LC).