### PR TITLE
Introduce metric aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.9.0
 
+- Add metric aggregation on client side in order to decrease the telemetry server load
 - Add `avail.light.starts` metric counter which allows measuring number of restarts
 - Add `http_server_port` CLI parameter for setting the http server port. Default HTTP server port set to 7007
 - Optimize expired kademlia records from RocksDB using compaction phase for removal

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -158,6 +158,7 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 			cfg.ot_collector_endpoint.clone(),
 			metric_attributes,
 			cfg.origin.clone(),
+			cfg.otel_flush_frequency_secs,
 		)
 		.wrap_err("Unable to initialize OpenTelemetry service")?,
 	);

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -11,7 +11,7 @@ use avail_light::{
 	sync_client::SyncClient,
 	sync_finality::SyncFinality,
 	telemetry::{self, otlp::MetricAttributes, MetricCounter, Metrics},
-	types::{CliOpts, IdentityConfig, LibP2PConfig, RuntimeConfig, State},
+	types::{CliOpts, IdentityConfig, LibP2PConfig, OtelConfig, RuntimeConfig, State},
 };
 use clap::Parser;
 use color_eyre::{
@@ -153,12 +153,13 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 			.unwrap_or("n/a".to_string()),
 	};
 
+	let cfg_otel: OtelConfig = (&cfg).into();
 	let ot_metrics = Arc::new(
 		telemetry::otlp::initialize(
 			cfg.ot_collector_endpoint.clone(),
 			metric_attributes,
 			cfg.origin.clone(),
-			cfg.otel_flush_frequency_secs,
+			cfg_otel,
 		)
 		.wrap_err("Unable to initialize OpenTelemetry service")?,
 	);

--- a/src/types.rs
+++ b/src/types.rs
@@ -425,6 +425,8 @@ pub struct RuntimeConfig {
 	pub log_format_json: bool,
 	/// OpenTelemetry Collector endpoint (default: `http://otelcollector.avail.tools:4317`)
 	pub ot_collector_endpoint: String,
+	pub ot_export_period: u64,
+	pub ot_export_timeout: u64,
 	pub otel_flush_frequency_secs: u64,
 	/// Disables fetching of cells from RPC, set to true if client expects cells to be available in DHT (default: false).
 	pub disable_rpc: bool,
@@ -822,6 +824,26 @@ impl From<&RuntimeConfig> for AppClientConfig {
 		}
 	}
 }
+
+#[derive(Clone, Debug)]
+pub struct OtelConfig {
+	pub ot_collector_endpoint: String,
+	pub ot_export_period: u64,
+	pub ot_export_timeout: u64,
+	pub otel_flush_frequency_secs: u64,
+}
+
+impl From<&RuntimeConfig> for OtelConfig {
+	fn from(val: &RuntimeConfig) -> Self {
+		OtelConfig {
+			ot_collector_endpoint: val.ot_collector_endpoint.clone(),
+			ot_export_period: val.ot_export_period,
+			ot_export_timeout: val.ot_export_timeout,
+			otel_flush_frequency_secs: val.otel_flush_frequency_secs,
+		}
+	}
+}
+
 impl Default for RuntimeConfig {
 	fn default() -> Self {
 		RuntimeConfig {
@@ -846,6 +868,8 @@ impl Default for RuntimeConfig {
 			log_level: "INFO".to_owned(),
 			log_format_json: false,
 			ot_collector_endpoint: "http://127.0.0.1:4317".to_string(),
+			ot_export_period: 300,
+			ot_export_timeout: 10,
 			otel_flush_frequency_secs: 10,
 			disable_rpc: false,
 			dht_parallelization_limit: 20,

--- a/src/types.rs
+++ b/src/types.rs
@@ -425,6 +425,7 @@ pub struct RuntimeConfig {
 	pub log_format_json: bool,
 	/// OpenTelemetry Collector endpoint (default: `http://otelcollector.avail.tools:4317`)
 	pub ot_collector_endpoint: String,
+	pub otel_flush_frequency_secs: u64,
 	/// Disables fetching of cells from RPC, set to true if client expects cells to be available in DHT (default: false).
 	pub disable_rpc: bool,
 	/// Maximum number of parallel tasks spawned for GET and PUT operations on DHT (default: 20).
@@ -845,6 +846,7 @@ impl Default for RuntimeConfig {
 			log_level: "INFO".to_owned(),
 			log_format_json: false,
 			ot_collector_endpoint: "http://127.0.0.1:4317".to_string(),
+			otel_flush_frequency_secs: 10,
 			disable_rpc: false,
 			dht_parallelization_limit: 20,
 			query_proof_rpc_parallel_tasks: 8,


### PR DESCRIPTION
- Added metric aggregation on client side in order to decrease the telemetry server load
- Health check (`up`) and `total_block_number` now send just the latest value
- Floating point gauges now send averages over a time period in seconds - `otel_flush_frequency_secs`
- Counters send the sum of all hits over the timespan
- Reduced the frequency of exports - external clients set to 300s


TODO: Address the 0% dht hit rate reported when no block available