### PR TITLE
Postpone flushing aggregated counters to maintanence.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 .env
 .DS_Store
 config*.yaml
-avail_light_store
-avail_path*
+avail_*
+debug.plist
 /identity.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v1.9.0
+## 1.9.1
+
+- Postpone flushing aggregated counters to maintanence step
+
+## [v1.9.0](https://github.com/availproject/avail-light/releases/tag/v1.9.0) - 2024-04-06
 
 - Add metric aggregation on client side in order to decrease the telemetry server load
 - Add `avail.light.starts` metric counter which allows measuring number of restarts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.1
 
+- Introduce `avail.light` namespace to the metrics
 - Postpone flushing aggregated counters to maintanence step
 
 ## [v1.9.0](https://github.com/availproject/avail-light/releases/tag/v1.9.0) - 2024-04-06

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "avail-light"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "async-std",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light"
-version = "1.9.0"
+version = "1.9.1"
 authors = ["Avail Team"]
 default-run = "avail-light"
 edition = "2021"

--- a/src/bin/avail-light.rs
+++ b/src/bin/avail-light.rs
@@ -254,7 +254,6 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 			result
 		},
 	)));
-	ot_metrics.count(MetricCounter::Starts).await;
 
 	info!("Waiting for first finalized header...");
 	let block_header = match shutdown
@@ -400,6 +399,7 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 		replication_factor: cfg.replication_factor,
 		query_timeout: cfg.query_timeout,
 		pruning_interval: cfg.store_pruning_interval,
+		telemetry_flush_interval: cfg.ot_flush_block_interval,
 	};
 
 	tokio::task::spawn(shutdown.with_cancel(avail_light::maintenance::run(
@@ -434,12 +434,14 @@ async fn run(shutdown: Controller<String>) -> Result<()> {
 			db.clone(),
 			light_network_client,
 			(&cfg).into(),
-			ot_metrics,
+			ot_metrics.clone(),
 			state.clone(),
 			channels,
 			shutdown.clone(),
 		)));
 	}
+
+	ot_metrics.count(MetricCounter::Starts).await;
 
 	Ok(())
 }

--- a/src/fat_client.rs
+++ b/src/fat_client.rs
@@ -81,9 +81,9 @@ pub async fn process_block(
 	received_at: Instant,
 	partition: Partition,
 ) -> Result<()> {
-	metrics.count(MetricCounter::SessionBlockCounter).await;
+	metrics.count(MetricCounter::SessionBlocks).await;
 	metrics
-		.record(MetricValue::TotalBlockNumber(header.number))
+		.record(MetricValue::BlockHeight(header.number))
 		.await;
 
 	let block_number = header.number;

--- a/src/fat_client.rs
+++ b/src/fat_client.rs
@@ -84,7 +84,7 @@ pub async fn process_block(
 	metrics.count(MetricCounter::SessionBlockCounter).await;
 	metrics
 		.record(MetricValue::TotalBlockNumber(header.number))
-		.await?;
+		.await;
 
 	let block_number = header.number;
 	let header_hash: H256 = Encode::using_encoded(header, blake2_256).into();
@@ -168,7 +168,7 @@ pub async fn process_block(
 		.record(MetricValue::RPCCallDuration(
 			partition_rpc_retrieve_time_elapsed.as_secs_f64(),
 		))
-		.await?;
+		.await;
 
 	if rpc_fetched.len() >= dimensions.cols().get().into() {
 		let data_cells = rpc_fetched
@@ -224,12 +224,9 @@ pub async fn run(
 		};
 
 		if let Some(seconds) = cfg.block_processing_delay.sleep_duration(received_at) {
-			if let Err(error) = metrics
+			metrics
 				.record(MetricValue::BlockProcessingDelay(seconds.as_secs_f64()))
-				.await
-			{
-				error!("Cannot record block processing delay: {}", error);
-			}
+				.await;
 			info!("Sleeping for {seconds:?} seconds");
 			tokio::time::sleep(seconds).await;
 		}
@@ -382,7 +379,7 @@ mod tests {
 
 		let mut mock_metrics = telemetry::MockMetrics::new();
 		mock_metrics.expect_count().returning(|_| ());
-		mock_metrics.expect_record().returning(|_| Ok(()));
+		mock_metrics.expect_record().returning(|_| ());
 
 		process_block(
 			&mock_client,

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -52,7 +52,7 @@ pub async fn process_block(
 	metrics.count(MetricCounter::SessionBlockCounter).await;
 	metrics
 		.record(MetricValue::TotalBlockNumber(header.number))
-		.await?;
+		.await;
 
 	let block_number = header.number;
 	let header_hash: H256 = Encode::using_encoded(&header, blake2_256).into();
@@ -109,30 +109,30 @@ pub async fn process_block(
 
 			metrics
 				.record(MetricValue::DHTFetched(fetch_stats.dht_fetched))
-				.await?;
+				.await;
 
 			metrics
 				.record(MetricValue::DHTFetchedPercentage(
 					fetch_stats.dht_fetched_percentage,
 				))
-				.await?;
+				.await;
 
 			metrics
 				.record(MetricValue::DHTFetchDuration(
 					fetch_stats.dht_fetch_duration,
 				))
-				.await?;
+				.await;
 
 			if let Some(rpc_fetched) = fetch_stats.rpc_fetched {
 				metrics
 					.record(MetricValue::NodeRPCFetched(rpc_fetched))
-					.await?;
+					.await;
 			}
 
 			if let Some(rpc_fetch_duration) = fetch_stats.rpc_fetch_duration {
 				metrics
 					.record(MetricValue::NodeRPCFetchDuration(rpc_fetch_duration))
-					.await?;
+					.await;
 			}
 			(positions.len(), fetched.len(), unfetched.len())
 		},
@@ -158,7 +158,7 @@ pub async fn process_block(
 	);
 	metrics
 		.record(MetricValue::BlockConfidence(confidence))
-		.await?;
+		.await;
 
 	// push latest mined block's header into column family specified
 	// for keeping block headers, to be used
@@ -210,12 +210,9 @@ pub async fn run(
 		};
 
 		if let Some(seconds) = cfg.block_processing_delay.sleep_duration(received_at) {
-			if let Err(error) = metrics
+			metrics
 				.record(MetricValue::BlockProcessingDelay(seconds.as_secs_f64()))
-				.await
-			{
-				error!("Cannot record block processing delay: {}", error);
-			}
+				.await;
 			info!("Sleeping for {seconds:?} seconds");
 			tokio::time::sleep(seconds).await;
 		}
@@ -354,7 +351,7 @@ mod tests {
 
 		let mut mock_metrics = telemetry::MockMetrics::new();
 		mock_metrics.expect_count().returning(|_| ());
-		mock_metrics.expect_record().returning(|_| Ok(()));
+		mock_metrics.expect_record().returning(|_| ());
 		process_block(
 			db,
 			&mock_network_client,

--- a/src/light_client.rs
+++ b/src/light_client.rs
@@ -49,9 +49,9 @@ pub async fn process_block(
 	received_at: Instant,
 	state: Arc<Mutex<State>>,
 ) -> Result<Option<f64>> {
-	metrics.count(MetricCounter::SessionBlockCounter).await;
+	metrics.count(MetricCounter::SessionBlocks).await;
 	metrics
-		.record(MetricValue::TotalBlockNumber(header.number))
+		.record(MetricValue::BlockHeight(header.number))
 		.await;
 
 	let block_number = header.number;
@@ -124,14 +124,12 @@ pub async fn process_block(
 				.await;
 
 			if let Some(rpc_fetched) = fetch_stats.rpc_fetched {
-				metrics
-					.record(MetricValue::NodeRPCFetched(rpc_fetched))
-					.await;
+				metrics.record(MetricValue::RPCFetched(rpc_fetched)).await;
 			}
 
 			if let Some(rpc_fetch_duration) = fetch_stats.rpc_fetch_duration {
 				metrics
-					.record(MetricValue::NodeRPCFetchDuration(rpc_fetch_duration))
+					.record(MetricValue::RPCFetchDuration(rpc_fetch_duration))
 					.await;
 			}
 			(positions.len(), fetched.len(), unfetched.len())

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -58,7 +58,7 @@ pub async fn process_block(
 	let connected_peers = p2p_client.list_connected_peers().await?;
 	debug!("Connected peers: {:?}", connected_peers);
 
-	let peers_num_metric = MetricValue::ConnectedPeersNum(peers_num);
+	let peers_num_metric = MetricValue::DHTConnectedPeers(peers_num);
 	metrics.record(peers_num_metric).await;
 
 	metrics
@@ -67,16 +67,16 @@ pub async fn process_block(
 		))
 		.await;
 	metrics
-		.record(MetricValue::ReplicationFactor(
+		.record(MetricValue::DHTReplicationFactor(
 			static_config_params.replication_factor,
 		))
 		.await;
 	metrics
-		.record(MetricValue::QueryTimeout(
+		.record(MetricValue::DHTQueryTimeout(
 			static_config_params.query_timeout,
 		))
 		.await;
-	metrics.record(MetricValue::HealthCheck()).await;
+	metrics.record(MetricValue::Up()).await;
 
 	info!(block_number, map_size, "Maintenance completed");
 	Ok(())

--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -247,10 +247,10 @@ impl EventLoop {
 					},
 					kad::Event::InboundRequest { request } => match request {
 						InboundRequest::GetRecord { .. } => {
-							metrics.count(MetricCounter::IncomingGetRecordCounter).await;
+							metrics.count(MetricCounter::IncomingGetRecord).await;
 						},
 						InboundRequest::PutRecord { source, record, .. } => {
-							metrics.count(MetricCounter::IncomingPutRecordCounter).await;
+							metrics.count(MetricCounter::IncomingPutRecord).await;
 							match record {
 								Some(mut record) => {
 									let ttl = &self.event_loop_config.kad_record_ttl;
@@ -459,7 +459,7 @@ impl EventLoop {
 			SwarmEvent::Behaviour(BehaviourEvent::Ping(ping::Event { result, .. })) => {
 				if let Ok(rtt) = result {
 					let _ = metrics
-						.record(MetricValue::PingLatency(rtt.as_millis() as f64))
+						.record(MetricValue::DHTPingLatency(rtt.as_millis() as f64))
 						.await;
 				}
 			},

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -12,6 +12,7 @@ use crate::types::Origin;
 
 pub mod otlp;
 
+#[derive(Debug)]
 pub enum MetricCounter {
 	Starts,
 	SessionBlockCounter,
@@ -39,6 +40,10 @@ impl Display for MetricCounter {
 }
 
 impl MetricCounter {
+	fn is_buffered(&self) -> bool {
+		!matches!(self, MetricCounter::Starts)
+	}
+
 	fn is_allowed(&self, origin: &Origin) -> bool {
 		match (origin, self) {
 			(Origin::External, MetricCounter::Starts) => true,
@@ -70,6 +75,7 @@ impl MetricCounter {
 	}
 }
 
+#[derive(Clone, Debug)]
 pub enum MetricValue {
 	TotalBlockNumber(u32),
 	DHTFetched(f64),
@@ -78,7 +84,7 @@ pub enum MetricValue {
 	NodeRPCFetched(f64),
 	NodeRPCFetchDuration(f64),
 	BlockConfidence(f64),
-	BlockConfidenceTreshold(f64),
+	BlockConfidenceThreshold(f64),
 	RPCCallDuration(f64),
 	DHTPutDuration(f64),
 	DHTPutSuccess(f64),
@@ -116,5 +122,6 @@ impl MetricValue {
 #[async_trait]
 pub trait Metrics {
 	async fn count(&self, counter: MetricCounter);
-	async fn record(&self, value: MetricValue) -> Result<()>;
+	async fn record(&self, value: MetricValue);
+	async fn flush(&self) -> Result<()>;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -427,7 +427,7 @@ pub struct RuntimeConfig {
 	pub ot_collector_endpoint: String,
 	pub ot_export_period: u64,
 	pub ot_export_timeout: u64,
-	pub otel_flush_frequency_secs: u64,
+	pub ot_flush_block_interval: u32,
 	/// Disables fetching of cells from RPC, set to true if client expects cells to be available in DHT (default: false).
 	pub disable_rpc: bool,
 	/// Maximum number of parallel tasks spawned for GET and PUT operations on DHT (default: 20).
@@ -830,7 +830,6 @@ pub struct OtelConfig {
 	pub ot_collector_endpoint: String,
 	pub ot_export_period: u64,
 	pub ot_export_timeout: u64,
-	pub otel_flush_frequency_secs: u64,
 }
 
 impl From<&RuntimeConfig> for OtelConfig {
@@ -839,7 +838,6 @@ impl From<&RuntimeConfig> for OtelConfig {
 			ot_collector_endpoint: val.ot_collector_endpoint.clone(),
 			ot_export_period: val.ot_export_period,
 			ot_export_timeout: val.ot_export_timeout,
-			otel_flush_frequency_secs: val.otel_flush_frequency_secs,
 		}
 	}
 }
@@ -870,7 +868,7 @@ impl Default for RuntimeConfig {
 			ot_collector_endpoint: "http://127.0.0.1:4317".to_string(),
 			ot_export_period: 300,
 			ot_export_timeout: 10,
-			otel_flush_frequency_secs: 10,
+			ot_flush_block_interval: 15,
 			disable_rpc: false,
 			dht_parallelization_limit: 20,
 			query_proof_rpc_parallel_tasks: 8,


### PR DESCRIPTION
This PR decouples metric flushing from recording and postpones flush to the maintenance step. It also moves `Starts` metric to the end og the light client initialization. 