### PR TITLE
feat: Add repo dispatch LC deployment

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -179,3 +179,23 @@ jobs:
           tags: availj/avail-light:${{ steps.prepare.outputs.tag_name }}
           build-args: |
             AVAIL_TAG=${{ steps.prepare.outputs.tag_name }}
+
+  lc_external_deployment:
+    needs:
+      - binary_publish
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Extract tag name
+        id: extract_tag
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Trigger repository dispatch for LC deployment
+        shell: bash
+        run: |
+          curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
+            ${{ secrets.DEPLOY_URL}} \
+            -d "{\"event_type\": \"lc_external_deployment\", \"client_payload\": {\"tag\": \"${{ env.TAG_NAME }}\"}}" \
+            | grep -q "204"


### PR DESCRIPTION
# Changelog
- [x] Introduces Automatic LC deployment based on new versions released on [avail-light repo](https://github.com/availproject/avail-light)

## Reason for Change
- Enables automatic LC deployments for testing new version on the networks

## Tests
- To be tested