### PR TITLE
Add `--block-matrix-partition` CLI parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [1.9.2]
+## 1.9.2
 
-- Fix default configuration for http_server_port
+- Add `--block-matrix-partition` CLI parameter
 - Introduce network name to metrics
 - Support enforcing minimum protocol version for agents on p2p network
+- Fix default configuration for http_server_port
 
 ## [1.9.1](https://github.com/availproject/avail-light/releases/tag/v1.9.1) - 2024-06-10
 


### PR DESCRIPTION
This PR adds --block-matrix-partition CLI parameter which start LC in fat client mode if supplied. Alternative to adding fat client related params to CLI is to move fat client to separate binary, related task will be created.