### PR TITLE
feat: MDNS Behaviour Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.10.2]
 
+- Prevent light clients in Kademlia client mode from getting added to routing table at mDNS step.
 - Fix a connectivity bug that caused peers to be removed from the routing table on connection error
 
 ## [1.10.1](https://github.com/availproject/avail-light/releases/tag/v1.10.1) - 2024-06-26

--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -415,7 +415,7 @@ impl EventLoop {
 							})
 							.collect();
 
-					let _ = self.swarm.behaviour_mut().identify.push(peer_ids);
+					self.swarm.behaviour_mut().identify.push(peer_ids);
 				},
 				mdns::Event::Expired(addrs_list) => {
 					addrs_list.into_iter().for_each(|(peer_id, multiaddr)| {


### PR DESCRIPTION
The following PR performs the following:- 
1. Prevents client mode LCs from getting added to routing table at mDNS step.