### PR TITLE
Replace peer count logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.2
 
+- Change the way peer counting is done and expose it through the P2P diagnostic API. Add the count of peers with external addresses.
 - Add `--block-matrix-partition` CLI parameter
 - Introduce network name to metrics
 - Support enforcing minimum protocol version for agents on p2p network

--- a/src/api/v2/README.md
+++ b/src/api/v2/README.md
@@ -249,7 +249,15 @@ This API is intended to be used for P2P network observability and diagnostics.
 
 ## **GET** `/v2/p2p/local/info`
 
-Returns `peer_id` and a list of listeners with both local and external addresses. External addresses are only populated once confirmed externally by the bootstrap.
+Returns:
+
+- `peer_id`
+- list of listeners with local addresses
+- list of listeners with external addresses
+- number of clients found in peers routing table
+- number of clients with non-private addresses found in the routing table
+
+External addresses are only populated once confirmed externally by the bootstrap.
 
 ```yaml
 HTTP/1.1 200 OK
@@ -265,8 +273,10 @@ Content-Type: application/json
     ],
     "external": [
       "{multi-address}"
-    ]
-  }
+    ],
+  },
+  "routing_table_peers_count": "{num}",
+  "routing_table_external_peers_count": "{num}",
 }
 ```
 

--- a/src/maintenance.rs
+++ b/src/maintenance.rs
@@ -52,8 +52,8 @@ pub async fn process_block(
 		.await
 		.wrap_err("Unable to get Kademlia map size")?;
 
-	let peers_num = p2p_client.count_dht_entries().await?;
-	info!("Number of connected peers: {peers_num}");
+	let (peers_num, pub_peers_num) = p2p_client.count_dht_entries().await?;
+	info!("Number of peers in the routing table: {peers_num}. Number of peers with public IPs: {pub_peers_num}.");
 
 	let connected_peers = p2p_client.list_connected_peers().await?;
 	debug!("Connected peers: {:?}", connected_peers);

--- a/src/network/p2p/client.rs
+++ b/src/network/p2p/client.rs
@@ -265,16 +265,14 @@ impl Command for CountKademliaPeers {
 		let mut peers_with_non_pvt_addr: usize = 0;
 		for bucket in entries.swarm.behaviour_mut().kademlia.kbuckets() {
 			for item in bucket.iter() {
-				for addr in item.node.value.iter() {
-					for protocol in addr.iter() {
-						if let libp2p::multiaddr::Protocol::Ip4(ip) = protocol {
-							if is_global(ip) {
-								peers_with_non_pvt_addr += 1;
-								// We just need to hit the first external address
-								break;
-							}
-						};
-					}
+				for protocol in item.node.value.iter().flat_map(|addr| addr.iter()) {
+					if let libp2p::multiaddr::Protocol::Ip4(ip) = protocol {
+						if is_global(ip) {
+							peers_with_non_pvt_addr += 1;
+							// We just need to hit the first external address
+							break;
+						}
+					};
 				}
 				total_peers += 1;
 			}

--- a/src/network/p2p/client.rs
+++ b/src/network/p2p/client.rs
@@ -255,19 +255,36 @@ impl Command for PutKadRecord {
 	fn abort(&mut self, _: Report) {}
 }
 
-struct CountConnectedPeers {
-	response_sender: Option<oneshot::Sender<Result<usize>>>,
+struct CountKademliaPeers {
+	response_sender: Option<oneshot::Sender<Result<(usize, usize)>>>,
 }
 
-impl Command for CountConnectedPeers {
+impl Command for CountKademliaPeers {
 	fn run(&mut self, entries: EventLoopEntries) -> Result<()> {
-		// send result back
-		// TODO: consider what to do if this results with None
+		let mut total_peers: usize = 0;
+		let mut peers_with_non_pvt_addr: usize = 0;
+		for bucket in entries.swarm.behaviour_mut().kademlia.kbuckets() {
+			for item in bucket.iter() {
+				let addresses = item.node.value.clone().into_vec();
+				for addr in addresses {
+					for protocol in addr.iter() {
+						if let libp2p::multiaddr::Protocol::Ip4(ip) = protocol {
+							if !ip.is_private() {
+								peers_with_non_pvt_addr += 1;
+								// We just need to hit the first external address
+								break;
+							}
+						};
+					}
+					total_peers += 1;
+				}
+			}
+		}
 		self.response_sender
 			.take()
 			.unwrap()
-			.send(Ok(entries.swarm.network_info().num_peers()))
-			.expect("CountDHTPeers receiver dropped");
+			.send(Ok((total_peers, peers_with_non_pvt_addr)))
+			.expect("CountKademliaPeers receiver dropped");
 		Ok(())
 	}
 
@@ -563,9 +580,9 @@ impl Client {
 			.context("receiver should not be dropped")
 	}
 
-	pub async fn count_dht_entries(&self) -> Result<usize> {
+	pub async fn count_dht_entries(&self) -> Result<(usize, usize)> {
 		self.execute_sync(|response_sender| {
-			Box::new(CountConnectedPeers {
+			Box::new(CountKademliaPeers {
 				response_sender: Some(response_sender),
 			})
 		})

--- a/src/network/p2p/client.rs
+++ b/src/network/p2p/client.rs
@@ -265,8 +265,7 @@ impl Command for CountKademliaPeers {
 		let mut peers_with_non_pvt_addr: usize = 0;
 		for bucket in entries.swarm.behaviour_mut().kademlia.kbuckets() {
 			for item in bucket.iter() {
-				let addresses = item.node.value.clone().into_vec();
-				for addr in addresses {
+				for addr in item.node.value.iter() {
 					for protocol in addr.iter() {
 						if let libp2p::multiaddr::Protocol::Ip4(ip) = protocol {
 							if is_global(ip) {
@@ -276,8 +275,8 @@ impl Command for CountKademliaPeers {
 							}
 						};
 					}
-					total_peers += 1;
 				}
+				total_peers += 1;
 			}
 		}
 		self.response_sender

--- a/src/network/p2p/client.rs
+++ b/src/network/p2p/client.rs
@@ -1,6 +1,6 @@
 use super::{
-	event_loop::ConnectionEstablishedInfo, Command, CommandSender, EventLoopEntries, LocalInfo,
-	QueryChannel, SendableCommand,
+	event_loop::ConnectionEstablishedInfo, is_global, Command, CommandSender, EventLoopEntries,
+	LocalInfo, QueryChannel, SendableCommand,
 };
 use color_eyre::{
 	eyre::{eyre, WrapErr},
@@ -269,7 +269,7 @@ impl Command for CountKademliaPeers {
 				for addr in addresses {
 					for protocol in addr.iter() {
 						if let libp2p::multiaddr::Protocol::Ip4(ip) = protocol {
-							if !ip.is_private() {
+							if is_global(ip) {
 								peers_with_non_pvt_addr += 1;
 								// We just need to hit the first external address
 								break;


### PR DESCRIPTION
- Peer counting is now done by traversing the Kademlia routing table instead of counting active connections
- Peers with non-private addresses are counted separately 
- `routing_table_peers_count` and `routing_table_external_peers_count` are added to the the `/v2/p2p/local/info` output