### PR TITLE
change the identify whitelisting logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.10.1]
+
+- Replace logic behind adding new peers in the Identify protocol handler to use Kademlia protocol name string instead of Identify agent string
+
 ## [1.10.0](https://github.com/availproject/avail-light/releases/tag/v1.10.0) - 2024-06-24
 
 - Application wide state is now persisted and not being kept in heap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "avail-light"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "async-std",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light"
-version = "1.10.0"
+version = "1.10.1"
 authors = ["Avail Team"]
 default-run = "avail-light"
 edition = "2021"

--- a/src/network/p2p/event_loop.rs
+++ b/src/network/p2p/event_loop.rs
@@ -360,13 +360,13 @@ impl EventLoop {
 					let incoming_peer_agent_version = match AgentVersion::from_str(&agent_version) {
 						Ok(agent) => agent,
 						Err(e) => {
-							info!("Error parsing incoming agent version: {e}");
+							debug!("Error parsing incoming agent version: {e}");
 							return;
 						},
 					};
 
 					if !incoming_peer_agent_version.is_supported() {
-						info!(
+						debug!(
 							"Unsupported release version: {}",
 							incoming_peer_agent_version.release_version
 						);
@@ -374,16 +374,9 @@ impl EventLoop {
 						return;
 					}
 
-					info!(
-						"Kademlia protocol {:?}",
-						self.swarm.behaviour_mut().kademlia.protocol_names()[0]
-					);
-
-					info!("Protocols: {:?}", protocols);
-
 					if protocols.contains(&self.swarm.behaviour_mut().kademlia.protocol_names()[0])
 					{
-						info!("Adding peer {peer_id} to routing table.");
+						trace!("Adding peer {peer_id} to routing table.");
 						for addr in listen_addrs {
 							self.swarm
 								.behaviour_mut()
@@ -392,7 +385,7 @@ impl EventLoop {
 						}
 					} else {
 						// Block and remove non-Avail peers
-						info!("Removing and blocking non-avail peer from routing table. Peer: {peer_id}. Agent: {agent_version}. Protocol: {protocol_version}");
+						debug!("Removing and blocking non-avail peer from routing table. Peer: {peer_id}. Agent: {agent_version}. Protocol: {protocol_version}");
 						self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
 					}
 				},


### PR DESCRIPTION
- Changed identify logic to use Kademlia protocol name instead of Identify user string
- For server mode clients, Kademlia protocol name is propagated using the Identify protocol; for client mode LCs, that's not the case
- This PR is a requirement for bringing back automatic Kademlia mode switches