### PR TITLE
fix incorrect doc for block_processing_delay's default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ disable_rpc = false
 query_proof_rpc_parallel_tasks = 8
 # Maximum number of cells per request for proof queries (default: 30).
 max_cells_per_rpc = 30
-# Number of seconds to postpone block processing after the block finalized message arrives. (default: 0).
+# Number of seconds to postpone block processing after the block finalized message arrives. (default: 20).
 block_processing_delay = 0
 # Starting block of the syncing process. Omitting it will disable syncing. (default: None).
 sync_start_block = 0

--- a/src/types.rs
+++ b/src/types.rs
@@ -434,7 +434,7 @@ pub struct RuntimeConfig {
 	pub dht_parallelization_limit: usize,
 	/// Number of parallel queries for cell fetching via RPC from node (default: 8).
 	pub query_proof_rpc_parallel_tasks: usize,
-	/// Number of seconds to postpone block processing after block finalized message arrives (default: 0).
+	/// Number of seconds to postpone block processing after block finalized message arrives (default: 20).
 	pub block_processing_delay: Option<u32>,
 	/// Fraction and number of the block matrix part to fetch (e.g. 2/20 means second 1/20 part of a matrix) (default: None)
 	#[serde(with = "block_matrix_partition_format")]


### PR DESCRIPTION
The doc seems incorrect, according to this line:

https://github.com/availproject/avail-light/blob/0b988917b16210b79a07fa9a95b2a0246e4b83db/src/types.rs#L938