### PR TITLE
Update operating mode in metrics on kademlia mode updates 

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.11.0]
 
+- Update operating mode metrics attribute on kademlia mode change
 - Fix storing the state of the verified data range
 - Re-enable automatic Kademlia mode switching from client to server if the pre-requisites are met
 

--- a/core/src/maintenance.rs
+++ b/core/src/maintenance.rs
@@ -51,7 +51,10 @@ pub async fn process_block(
 
 	// Reconfigure Kademlia mode if needed
 	if maintenance_config.automatic_server_mode {
-		_ = p2p_client.reconfigure_kademlia_mode(maintenance_config.into());
+		_ = p2p_client.reconfigure_kademlia_mode(
+			maintenance_config.total_memory_gb_threshold,
+			maintenance_config.num_cpus_threshold,
+		);
 	}
 
 	let peers_num_metric = MetricValue::DHTConnectedPeers(peers_num);

--- a/core/src/network/p2p.rs
+++ b/core/src/network/p2p.rs
@@ -2,7 +2,7 @@ use allow_block_list::BlockedPeers;
 use color_eyre::{eyre::WrapErr, Report, Result};
 use libp2p::{
 	autonat, dcutr, identify, identity,
-	kad::{self, PeerRecord, QueryId},
+	kad::{self, Mode, PeerRecord, QueryId},
 	mdns, noise, ping, relay,
 	swarm::NetworkBehaviour,
 	tcp, upnp, yamux, PeerId, Swarm, SwarmBuilder,
@@ -48,6 +48,7 @@ pub struct EventLoopEntries<'a> {
 		&'a mut HashMap<PeerId, oneshot::Sender<Result<ConnectionEstablishedInfo>>>,
 	/// <block_num, (total_cells, result_cell_counter, time_stat)>
 	active_blocks: &'a mut HashMap<u32, BlockStat>,
+	kad_mode: &'a Mode,
 }
 
 impl<'a> EventLoopEntries<'a> {
@@ -59,12 +60,14 @@ impl<'a> EventLoopEntries<'a> {
 			oneshot::Sender<Result<ConnectionEstablishedInfo>>,
 		>,
 		active_blocks: &'a mut HashMap<u32, BlockStat>,
+		mode: &'a Mode,
 	) -> Self {
 		Self {
 			swarm,
 			pending_kad_queries,
 			pending_swarm_events,
 			active_blocks,
+			kad_mode: mode,
 		}
 	}
 

--- a/core/src/network/p2p/event_loop.rs
+++ b/core/src/network/p2p/event_loop.rs
@@ -271,6 +271,7 @@ impl EventLoop {
 					kad::Event::ModeChanged { new_mode } => {
 						trace!("Kademlia mode changed: {new_mode:?}");
 						self.kad_mode = new_mode;
+						metrics.update_operating_mode(new_mode).await
 					},
 					kad::Event::OutboundQueryProgressed {
 						id, result, stats, ..

--- a/core/src/network/p2p/event_loop.rs
+++ b/core/src/network/p2p/event_loop.rs
@@ -270,6 +270,9 @@ impl EventLoop {
 					},
 					kad::Event::ModeChanged { new_mode } => {
 						trace!("Kademlia mode changed: {new_mode:?}");
+						if let (Mode::Client, Mode::Server) = (self.kad_mode, new_mode) {
+							metrics.count(MetricCounter::ServerModeSwitch).await;
+						};
 						self.kad_mode = new_mode;
 					},
 					kad::Event::OutboundQueryProgressed {

--- a/core/src/network/p2p/event_loop.rs
+++ b/core/src/network/p2p/event_loop.rs
@@ -270,9 +270,6 @@ impl EventLoop {
 					},
 					kad::Event::ModeChanged { new_mode } => {
 						trace!("Kademlia mode changed: {new_mode:?}");
-						if let (Mode::Client, Mode::Server) = (self.kad_mode, new_mode) {
-							metrics.count(MetricCounter::ServerModeSwitch).await;
-						};
 						self.kad_mode = new_mode;
 					},
 					kad::Event::OutboundQueryProgressed {

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -16,7 +16,6 @@ pub enum MetricCounter {
 	EstablishedConnections,
 	IncomingPutRecord,
 	IncomingGetRecord,
-	ServerModeSwitch,
 }
 
 pub trait MetricName {
@@ -36,14 +35,13 @@ impl MetricName for MetricCounter {
 			EstablishedConnections => "avail.light.established_connections",
 			IncomingPutRecord => "avail.light.incoming_put_record",
 			IncomingGetRecord => "avail.light.incoming_get_record",
-			ServerModeSwitch => "avail.light.server_mode_switch",
 		}
 	}
 }
 
 impl MetricCounter {
 	fn is_buffered(&self) -> bool {
-		!(matches!(self, MetricCounter::Starts) || matches!(self, MetricCounter::ServerModeSwitch))
+		!matches!(self, MetricCounter::Starts)
 	}
 
 	fn as_last(&self) -> bool {
@@ -54,7 +52,6 @@ impl MetricCounter {
 		match (origin, self) {
 			(Origin::External, MetricCounter::Starts) => true,
 			(Origin::External, MetricCounter::Up) => true,
-			(Origin::External, MetricCounter::ServerModeSwitch) => true,
 			(Origin::External, _) => false,
 			(_, _) => true,
 		}

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -16,6 +16,7 @@ pub enum MetricCounter {
 	EstablishedConnections,
 	IncomingPutRecord,
 	IncomingGetRecord,
+	ServerModeSwitch,
 }
 
 pub trait MetricName {
@@ -35,13 +36,14 @@ impl MetricName for MetricCounter {
 			EstablishedConnections => "avail.light.established_connections",
 			IncomingPutRecord => "avail.light.incoming_put_record",
 			IncomingGetRecord => "avail.light.incoming_get_record",
+			ServerModeSwitch => "avail.light.server_mode_switch",
 		}
 	}
 }
 
 impl MetricCounter {
 	fn is_buffered(&self) -> bool {
-		!matches!(self, MetricCounter::Starts)
+		!(matches!(self, MetricCounter::Starts) || matches!(self, MetricCounter::ServerModeSwitch))
 	}
 
 	fn as_last(&self) -> bool {
@@ -52,6 +54,7 @@ impl MetricCounter {
 		match (origin, self) {
 			(Origin::External, MetricCounter::Starts) => true,
 			(Origin::External, MetricCounter::Up) => true,
+			(Origin::External, MetricCounter::ServerModeSwitch) => true,
 			(Origin::External, _) => false,
 			(_, _) => true,
 		}

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -1,6 +1,7 @@
 use crate::types::Origin;
 use async_trait::async_trait;
 use color_eyre::Result;
+use libp2p::kad::Mode;
 use mockall::automock;
 
 pub mod otlp;
@@ -144,4 +145,5 @@ pub trait Metrics {
 	async fn count(&self, counter: MetricCounter);
 	async fn record(&self, value: MetricValue);
 	async fn flush(&self) -> Result<()>;
+	async fn update_operating_mode(&self, mode: Mode);
 }

--- a/core/src/telemetry/otlp.rs
+++ b/core/src/telemetry/otlp.rs
@@ -229,6 +229,7 @@ fn init_counters(meter: Meter, origin: Origin) -> HashMap<&'static str, Counter<
 		MetricCounter::EstablishedConnections,
 		MetricCounter::IncomingPutRecord,
 		MetricCounter::IncomingGetRecord,
+		MetricCounter::ServerModeSwitch,
 	]
 	.iter()
 	.filter(|counter| MetricCounter::is_allowed(counter, &origin))
@@ -303,6 +304,7 @@ mod tests {
 			Starts,
 			IncomingGetRecord,
 			Up,
+			ServerModeSwitch,
 			IncomingPutRecord,
 			Starts,
 		];
@@ -314,6 +316,7 @@ mod tests {
 		expected.insert(IncomingConnectionErrors.name(), 2);
 		expected.insert(IncomingConnections.name(), 1);
 		expected.insert(IncomingGetRecord.name(), 1);
+		expected.insert(ServerModeSwitch.name(), 1);
 		expected.insert(IncomingPutRecord.name(), 1);
 		assert_eq!(result, expected);
 	}

--- a/core/src/telemetry/otlp.rs
+++ b/core/src/telemetry/otlp.rs
@@ -229,7 +229,6 @@ fn init_counters(meter: Meter, origin: Origin) -> HashMap<&'static str, Counter<
 		MetricCounter::EstablishedConnections,
 		MetricCounter::IncomingPutRecord,
 		MetricCounter::IncomingGetRecord,
-		MetricCounter::ServerModeSwitch,
 	]
 	.iter()
 	.filter(|counter| MetricCounter::is_allowed(counter, &origin))
@@ -304,7 +303,6 @@ mod tests {
 			Starts,
 			IncomingGetRecord,
 			Up,
-			ServerModeSwitch,
 			IncomingPutRecord,
 			Starts,
 		];
@@ -316,7 +314,6 @@ mod tests {
 		expected.insert(IncomingConnectionErrors.name(), 2);
 		expected.insert(IncomingConnections.name(), 1);
 		expected.insert(IncomingGetRecord.name(), 1);
-		expected.insert(ServerModeSwitch.name(), 1);
 		expected.insert(IncomingPutRecord.name(), 1);
 		assert_eq!(result, expected);
 	}

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -24,7 +24,6 @@ use std::time::{Duration, Instant};
 use subxt_signer::bip39::{Language, Mnemonic};
 use subxt_signer::sr25519::Keypair;
 use subxt_signer::{SecretString, SecretUri};
-use sysinfo::System;
 use tokio::sync::broadcast;
 use tokio_retry::strategy::{jitter, ExponentialBackoff, FibonacciBackoff};
 use tracing::warn;
@@ -705,7 +704,7 @@ pub struct AgentVersion {
 	pub release_version: String,
 }
 
-impl Display for AgentVersion {
+impl fmt::Display for AgentVersion {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(
 			f,
@@ -1047,44 +1046,5 @@ impl TimeToLive {
 	/// Expiry at instant from now
 	pub fn expires(&self) -> Option<Instant> {
 		Instant::now().checked_add(self.0)
-	}
-}
-
-const BYTES_IN_GB: usize = 1024 * 1024 * 1024;
-
-pub struct SystemResources {
-	pub memory_gb: f64,
-	pub cpus: usize,
-}
-
-impl From<MaintenanceConfig> for SystemResources {
-	fn from(value: MaintenanceConfig) -> Self {
-		Self {
-			memory_gb: value.total_memory_gb_threshold,
-			cpus: value.num_cpus_threshold,
-		}
-	}
-}
-
-impl SystemResources {
-	pub fn current() -> Self {
-		let sys = System::new_all();
-		Self {
-			memory_gb: sys.total_memory() as f64 / BYTES_IN_GB as f64,
-			cpus: sys.cpus().len(),
-		}
-	}
-
-	pub fn is_above(&self, threshold: &SystemResources) -> bool {
-		self.memory_gb > threshold.memory_gb && self.cpus > threshold.cpus
-	}
-}
-
-impl Display for SystemResources {
-	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-		let Self { memory_gb, cpus } = self;
-		f.write_str(&format!(
-			"Total memory: {memory_gb} GB, CPU core count: {cpus}"
-		))
 	}
 }

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -24,6 +24,7 @@ use std::time::{Duration, Instant};
 use subxt_signer::bip39::{Language, Mnemonic};
 use subxt_signer::sr25519::Keypair;
 use subxt_signer::{SecretString, SecretUri};
+use sysinfo::System;
 use tokio::sync::broadcast;
 use tokio_retry::strategy::{jitter, ExponentialBackoff, FibonacciBackoff};
 use tracing::warn;
@@ -704,7 +705,7 @@ pub struct AgentVersion {
 	pub release_version: String,
 }
 
-impl fmt::Display for AgentVersion {
+impl Display for AgentVersion {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(
 			f,
@@ -1046,5 +1047,44 @@ impl TimeToLive {
 	/// Expiry at instant from now
 	pub fn expires(&self) -> Option<Instant> {
 		Instant::now().checked_add(self.0)
+	}
+}
+
+const BYTES_IN_GB: usize = 1024 * 1024 * 1024;
+
+pub struct SystemResources {
+	pub memory_gb: f64,
+	pub cpus: usize,
+}
+
+impl From<MaintenanceConfig> for SystemResources {
+	fn from(value: MaintenanceConfig) -> Self {
+		Self {
+			memory_gb: value.total_memory_gb_threshold,
+			cpus: value.num_cpus_threshold,
+		}
+	}
+}
+
+impl SystemResources {
+	pub fn current() -> Self {
+		let sys = System::new_all();
+		Self {
+			memory_gb: sys.total_memory() as f64 / BYTES_IN_GB as f64,
+			cpus: sys.cpus().len(),
+		}
+	}
+
+	pub fn is_above(&self, threshold: &SystemResources) -> bool {
+		self.memory_gb > threshold.memory_gb && self.cpus > threshold.cpus
+	}
+}
+
+impl Display for SystemResources {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		let Self { memory_gb, cpus } = self;
+		f.write_str(&format!(
+			"Total memory: {memory_gb} GB, CPU core count: {cpus}"
+		))
 	}
 }


### PR DESCRIPTION
This PR introduces update of operating mode in metrics on kademlia mode switches. It also moves entire switching logic into the command, so it can be read and changed on one place. 