### PR TITLE
introduce public address filter for external addresses

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [1.11.2]
 
+- Introduce public address filter for external addresses and add additional log entry
+- Refactor the `/peers/get-multiaddress` endpoint so that it returns all of the peers multi-addresses
 - Fix `operating_mode` metric attribute not switching properly when Kademlia mode changes
 
 ## [1.11.1](https://github.com/availproject/avail-light/releases/tag/avail-light-client-v1.11.1) - 2024-07-23

--- a/core/src/api/v2/handlers/p2p.rs
+++ b/core/src/api/v2/handlers/p2p.rs
@@ -1,4 +1,7 @@
-use crate::{api::v2::types::Error, network::p2p};
+use crate::{
+	api::v2::types::Error,
+	network::p2p::{self, MultiAddressInfo},
+};
 use libp2p::{swarm::DialError, Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
 use warp::reply::Reply;
@@ -56,15 +59,12 @@ pub struct PeerInfoQuery {
 	pub peer_id: PeerId,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MultiAddressResponse {
-	pub multiaddress_list: Vec<String>,
-	pub peer_id: String,
-}
+#[derive(Debug)]
+pub struct MultiAddressResponse(MultiAddressInfo);
 
 impl Reply for MultiAddressResponse {
 	fn into_response(self) -> warp::reply::Response {
-		warp::reply::json(&self).into_response()
+		warp::reply::json(&self.0).into_response()
 	}
 }
 
@@ -107,7 +107,7 @@ pub async fn get_peer_multiaddr(
 		.await
 		.map_err(Error::internal_server_error)?;
 
-	Ok(external_peer_info)
+	Ok(MultiAddressResponse(external_peer_info))
 }
 
 pub async fn dial_external_peer(

--- a/core/src/api/v2/mod.rs
+++ b/core/src/api/v2/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 	types::{IdentityConfig, RuntimeConfig},
 };
 
-mod handlers;
+pub mod handlers;
 mod transactions;
 pub mod types;
 mod ws;

--- a/core/src/api/v2/mod.rs
+++ b/core/src/api/v2/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 	types::{IdentityConfig, RuntimeConfig},
 };
 
-pub mod handlers;
+mod handlers;
 mod transactions;
 pub mod types;
 mod ws;

--- a/core/src/network/p2p.rs
+++ b/core/src/network/p2p.rs
@@ -8,6 +8,7 @@ use libp2p::{
 	tcp, upnp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
 use multihash::{self, Hasher};
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, net::Ipv4Addr};
 use tokio::sync::{
 	mpsc::{self},
@@ -146,6 +147,12 @@ pub struct PeerInfo {
 	pub local_listeners: Vec<String>,
 	pub external_listeners: Vec<String>,
 	pub public_listeners: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MultiAddressInfo {
+	multiaddresses: Vec<String>,
+	peer_id: String,
 }
 
 fn generate_config(config: libp2p::swarm::Config, cfg: &LibP2PConfig) -> libp2p::swarm::Config {

--- a/core/src/network/p2p.rs
+++ b/core/src/network/p2p.rs
@@ -145,6 +145,7 @@ pub struct PeerInfo {
 	pub peer_multiaddr: Option<Vec<String>>,
 	pub local_listeners: Vec<String>,
 	pub external_listeners: Vec<String>,
+	pub public_listeners: Vec<String>,
 }
 
 fn generate_config(config: libp2p::swarm::Config, cfg: &LibP2PConfig) -> libp2p::swarm::Config {

--- a/core/src/network/p2p/client.rs
+++ b/core/src/network/p2p/client.rs
@@ -1,8 +1,8 @@
 use crate::api::v2::handlers::p2p::MultiAddressResponse;
 
 use super::{
-	event_loop::ConnectionEstablishedInfo, is_global, Command, CommandSender, EventLoopEntries,
-	PeerInfo, QueryChannel, SendableCommand,
+	event_loop::ConnectionEstablishedInfo, is_global, is_multiaddr_global, Command, CommandSender,
+	EventLoopEntries, PeerInfo, QueryChannel, SendableCommand,
 };
 use color_eyre::{
 	eyre::{eyre, WrapErr},
@@ -268,14 +268,12 @@ impl Command for CountKademliaPeers {
 		let mut peers_with_non_pvt_addr: usize = 0;
 		for bucket in entries.swarm.behaviour_mut().kademlia.kbuckets() {
 			for item in bucket.iter() {
-				for protocol in item.node.value.iter().flat_map(|addr| addr.iter()) {
-					if let libp2p::multiaddr::Protocol::Ip4(ip) = protocol {
-						if is_global(ip) {
-							peers_with_non_pvt_addr += 1;
-							// We just need to hit the first external address
-							break;
-						}
-					};
+				for address in item.node.value.iter() {
+					if is_multiaddr_global(address) {
+						peers_with_non_pvt_addr += 1;
+						// We just need to hit the first external address
+						break;
+					}
 				}
 				total_peers += 1;
 			}

--- a/core/src/network/p2p/event_loop.rs
+++ b/core/src/network/p2p/event_loop.rs
@@ -28,7 +28,7 @@ use tokio::{
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{
-	network::p2p::is_global,
+	network::p2p::is_multiaddr_global,
 	shutdown::Controller,
 	telemetry::{MetricCounter, MetricValue, Metrics},
 	types::{AgentVersion, KademliaMode, LibP2PConfig, TimeToLive},
@@ -521,9 +521,7 @@ impl EventLoop {
 							"External reachability confirmed on address: {}",
 							address.to_string()
 						);
-						if address.iter().any(
-							|protocol| matches!(protocol, libp2p::multiaddr::Protocol::Ip4(ip) if is_global(ip)),
-						) {
+						if is_multiaddr_global(&address) {
 							info!(
 								"Public reachability confirmed on address: {}",
 								address.to_string()

--- a/core/src/network/p2p/event_loop.rs
+++ b/core/src/network/p2p/event_loop.rs
@@ -272,6 +272,9 @@ impl EventLoop {
 					},
 					kad::Event::ModeChanged { new_mode } => {
 						trace!("Kademlia mode changed: {new_mode:?}");
+						// This event should not be automatically triggered because the mode changes are handled explicitly through the LC logic
+						self.kad_mode = new_mode;
+						metrics.update_operating_mode(new_mode).await
 					},
 					kad::Event::OutboundQueryProgressed {
 						id, result, stats, ..


### PR DESCRIPTION
- Introduce public address filter for external addresses and add additional log entry
- Refactor the `/peers/get-multiaddress` endpoint so that it returns all of the peers multi-addresses