### PR TITLE
Update changelog structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "avail-light-crawler"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "avail-light-core",
  "avail-rust",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "avail-light-fat"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "avail-light-core",
  "avail-rust",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.12.1
 
-- Core changes are enumerated in [`core` CHANGELOG](../core/CHANGELOG.md) under the version 1.12.1
+- Update avail-light-core to 1.0.3
 
 ## [1.12.0](https://github.com/availproject/avail-light/releases/tag/avail-light-client-v1.12.0) - 2024-09-27
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## 1.12.1
+## 1.0.3
 
 - Fix skipping of only available node during retries in case of intermittent failure
 - Increase maximum retry delay to 10 seconds
+
+# Changelog (pre-monorepo)
 
 ## 1.12.0
 

--- a/crawler/CHANGELOG.md
+++ b/crawler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1
+
+- Update avail-light-core to 1.0.3
+
 ## 0.1.0
 
 - Add initial crawler implementation

--- a/crawler/Cargo.toml
+++ b/crawler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light-crawler"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 build = "../build.rs"
 edition = "2021"

--- a/fat/CHANGELOG.md
+++ b/fat/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.12.1
+
+- Update avail-light-core to 1.0.3
+
 ## [1.12.0](https://github.com/availproject/avail-light/releases/tag/avail-light-fat-v1.12.0) - 2024-09-27
 
 - Add initial fat client implementation

--- a/fat/Cargo.toml
+++ b/fat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light-fat"
-version = "1.12.0"
+version = "1.12.1"
 authors.workspace = true
 build = "../build.rs"
 edition = "2021"


### PR DESCRIPTION
This PR addresses the issue of versioning avail-light-core crate. Since we don't release it to crates.io and since we have monorepo, versioning and changelog is tightly coupled to crates in this workspace that dependends on it. To decouple version number and changes in the avail-light-core, following steps are proposed:

- We are versioning avail-light-core independently
- Each increment in the version of the avail-light-core should be reflected in the version and documented in the individual changelogs of the crate which depends on it
- There is no link to release since we don't release it
- When any crate that depends on it is released, we mark avail-light-core as released by adding a date, and continue from first step

Every client release should have description with a link to tagged version of main change log which would allow to observe exact changes included in release. This should ease maintenance and remove confusion from release process.   