### PR TITLE
integrate new automatic bootstrap mechanism on bootnode

### DIFF
--- a/bootstrap/CHANGELOG.md
+++ b/bootstrap/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.4.0]
 
+- Integrate upstream `rust-libp2p` `0.54` changes to the bootstrap process
 - Add `/p2p/local/info` endpoint
 - Add webrtc support to bootstrap
 

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -148,9 +148,10 @@ async fn run() -> Result<()> {
 		network_client
 			.add_bootstrap_nodes(cfg.bootstraps.iter().map(Into::into).collect())
 			.await?;
+	} else {
+		info!("No bootstrap list provided, starting client as the first bootstrap on the network.")
 	}
-	network_client.bootstrap().await?;
-	info!("Bootstrap done.");
+
 	loop_handle.await?;
 
 	Ok(())

--- a/bootstrap/src/p2p.rs
+++ b/bootstrap/src/p2p.rs
@@ -64,7 +64,9 @@ pub async fn init(
 	let kad_store = MemoryStore::new(id_keys.public().to_peer_id());
 	// create Kademlia Config
 	let mut kad_cfg = kad::Config::new(cfg.kademlia.protocol_name);
-	kad_cfg.set_query_timeout(cfg.kademlia.query_timeout);
+	kad_cfg
+		.set_query_timeout(cfg.kademlia.query_timeout)
+		.set_periodic_bootstrap_interval(Some(cfg.kademlia.bootstrap_interval));
 	// build the Swarm, connecting the lower transport logic with the
 	// higher layer network behaviour logic
 	let tokio_swarm = SwarmBuilder::with_existing_identity(id_keys.clone()).with_tokio();
@@ -112,7 +114,7 @@ pub async fn init(
 
 	Ok((
 		Client::new(command_sender),
-		EventLoop::new(swarm, command_receiver, cfg.bootstrap_interval),
+		EventLoop::new(swarm, command_receiver),
 	))
 }
 

--- a/bootstrap/src/p2p/client.rs
+++ b/bootstrap/src/p2p/client.rs
@@ -63,6 +63,7 @@ impl Client {
 			.context("Sender not to be dropped.")?
 	}
 
+	// Checks if bootstraps are available and adds them to the routing table automatically triggering bootstrap process
 	pub async fn add_bootstrap_nodes(&self, nodes: Vec<(PeerId, Multiaddr)>) -> Result<()> {
 		for (peer, addr) in nodes {
 			self.dial_peer(peer, addr.clone())
@@ -72,43 +73,6 @@ impl Client {
 		}
 
 		Ok(())
-	}
-
-	pub async fn bootstrap(&self) -> Result<()> {
-		// bootstrapping is impossible on an empty DHT table
-		// at least one node is required to be known, so check
-		let counted_peers = self.count_dht_entries().await?;
-		// for a bootstrap to succeed, we need at least 1 peer in our DHT
-		if counted_peers < 1 {
-			// we'll have to wait, until some one successfully connects us
-			let (peer_id, multiaddr) = self.wait_connection(None).await?;
-			// add that peer to have someone to bootstrap with
-			self.add_address(peer_id, multiaddr).await?;
-		}
-
-		// proceed to bootstrap only if connected with someone
-		let (boot_res_sender, boot_res_receiver) = oneshot::channel();
-		self.command_sender
-			.send(Command::Bootstrap {
-				response_sender: boot_res_sender,
-			})
-			.await
-			.context("Command receiver should not be dropped while bootstrapping.")?;
-		boot_res_receiver
-			.await
-			.context("Sender not to be dropped while bootstrapping.")?
-	}
-
-	async fn wait_connection(&self, peer_id: Option<PeerId>) -> Result<(PeerId, Multiaddr)> {
-		let (connection_res_sender, connection_res_receiver) = oneshot::channel();
-		self.command_sender
-			.send(Command::WaitConnection {
-				peer_id,
-				response_sender: connection_res_sender,
-			})
-			.await
-			.context("Command receiver should not be dropped while waiting on connection.")?;
-		Ok(connection_res_receiver.await?)
 	}
 
 	pub async fn count_dht_entries(&self) -> Result<usize> {
@@ -154,13 +118,6 @@ pub enum Command {
 		peer_id: PeerId,
 		multiaddr: Multiaddr,
 		response_sender: oneshot::Sender<Result<()>>,
-	},
-	Bootstrap {
-		response_sender: oneshot::Sender<Result<()>>,
-	},
-	WaitConnection {
-		peer_id: Option<PeerId>,
-		response_sender: oneshot::Sender<(PeerId, Multiaddr)>,
 	},
 	CountDHTPeers {
 		response_sender: oneshot::Sender<usize>,

--- a/bootstrap/src/types.rs
+++ b/bootstrap/src/types.rs
@@ -114,7 +114,6 @@ pub struct LibP2PConfig {
 	pub identify: IdentifyConfig,
 	pub kademlia: KademliaConfig,
 	pub secret_key: Option<SecretKey>,
-	pub bootstrap_interval: Duration,
 }
 
 impl From<&RuntimeConfig> for LibP2PConfig {
@@ -124,7 +123,6 @@ impl From<&RuntimeConfig> for LibP2PConfig {
 			identify: IdentifyConfig::new(),
 			kademlia: rtcfg.into(),
 			secret_key: rtcfg.secret_key.clone(),
-			bootstrap_interval: Duration::from_secs(rtcfg.bootstrap_period),
 		}
 	}
 }
@@ -133,6 +131,7 @@ impl From<&RuntimeConfig> for LibP2PConfig {
 pub struct KademliaConfig {
 	pub query_timeout: Duration,
 	pub protocol_name: StreamProtocol,
+	pub bootstrap_interval: Duration,
 }
 
 impl From<&RuntimeConfig> for KademliaConfig {
@@ -149,6 +148,7 @@ impl From<&RuntimeConfig> for KademliaConfig {
 		KademliaConfig {
 			query_timeout: Duration::from_secs(val.kad_query_timeout.into()),
 			protocol_name,
+			bootstrap_interval: Duration::from_secs(val.bootstrap_period),
 		}
 	}
 }


### PR DESCRIPTION
- Replace custom automatic bootstrap with the new upstream solution from `rust-libp2p` 0.54
- Remove waiting for first connections in favor of logging the `ConnectionEstablished` event once it happens
- Bootstrap complete events are now just printed in the event loop instead of being propagated
- Moved `bootstrap_interval` to `KademliaConfig`