### PR TITLE
fix: Moves compat test to gh hosted runners

### DIFF
--- a/.github/workflows/avail-light-client.yml
+++ b/.github/workflows/avail-light-client.yml
@@ -92,7 +92,7 @@ jobs:
 
 
   compatibility_tests:
-    runs-on: self-hosted
+    runs-on: lc-gh-runner
     steps:
       - run: docker-compose --version
       


### PR DESCRIPTION
# Motivation
- Compatibility tests are stuck due to decommissioned runners infra.

# Changes
 - [x] Moves compat test to gh hosted runners.