### PR TITLE
Set swarm idle timeout

### DIFF
--- a/bootstrap/src/p2p.rs
+++ b/bootstrap/src/p2p.rs
@@ -88,6 +88,7 @@ pub async fn init(
 			.with_websocket(noise::Config::new, yamux::Config::default)
 			.await?
 			.with_behaviour(behaviour)?
+			.with_swarm_config(|c| c.with_idle_connection_timeout(cfg.connection_idle_timeout))
 			.build()
 	} else {
 		swarm = tokio_swarm
@@ -103,6 +104,7 @@ pub async fn init(
 			})?
 			.with_dns()?
 			.with_behaviour(behaviour)?
+			.with_swarm_config(|c| c.with_idle_connection_timeout(cfg.connection_idle_timeout))
 			.build()
 	}
 

--- a/bootstrap/src/types.rs
+++ b/bootstrap/src/types.rs
@@ -114,6 +114,7 @@ pub struct LibP2PConfig {
 	pub identify: IdentifyConfig,
 	pub kademlia: KademliaConfig,
 	pub secret_key: Option<SecretKey>,
+	pub connection_idle_timeout: Duration,
 }
 
 impl From<&RuntimeConfig> for LibP2PConfig {
@@ -123,6 +124,7 @@ impl From<&RuntimeConfig> for LibP2PConfig {
 			identify: IdentifyConfig::new(),
 			kademlia: rtcfg.into(),
 			secret_key: rtcfg.secret_key.clone(),
+			connection_idle_timeout: Duration::from_secs(rtcfg.connection_idle_timeout),
 		}
 	}
 }


### PR DESCRIPTION
Having an idle connection timeout value of 0 makes it hard to open a stream to the rust bootstrappers. On the Go side, we're dialing the peer and then doing the identify exchange. Only after this exchange has completed, we can open a stream. However, in this short period of time rust-libp2p will prune the connection because it's idle.

One fix on our side is to only dial the bootstrapper and then do our crawling/fetching/etc. in parallel to the identify exchange. However, this is only a bandaid solution. It would be better to allow connecting peers a little bit of time to prove their usefulness.

This is also discussed in rust-libp2p here: https://github.com/libp2p/rust-libp2p/issues/4912

Theoretically, the issue could be amplified in situations where the rust peer is overloaded and the state machine can't keep up with events. The connection may be considered idle and get pruned although there is an "open stream"-event waiting to be consumed.

Moreover, as far as I can tell, the connection_idle_timeout configuration parameter isn't even used anywhere.

This PR is should just be a discussion starter. If this gets merged, I guess you would want to apply the changes to your other components (like light clients) as well.

cc @vbhattaccmu

for context my discuss.libp2p post: https://discuss.libp2p.io/t/rust-go-interop-idle-connection-timeout-race-condition/2470/3

PS: Copy of https://github.com/availproject/avail-light-bootstrap/pull/29