### PR TITLE
decrease swarm connection idle timeout to 10s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "avail-light-bootstrap"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1010,6 +1010,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "confy 0.5.1",
+ "convert_case 0.6.0",
  "derive_more 0.99.18",
  "dusk-plonk",
  "futures",

--- a/bootstrap/CHANGELOG.md
+++ b/bootstrap/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.1]
+
+- Decrease connection idle timeout to 10s
+
 ## [0.4.0](https://github.com/availproject/avail-light/releases/tag/avail-light-bootstrap-v0.4.0) - 2024-11-05
 
 - Fix missing swarm config

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail-light-bootstrap"
-version = "0.4.0"
+version = "0.4.1"
 build = "../build.rs"
 edition = "2021"
 description = "Avail network Bootstrap Node for p2p Light Client"

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -40,8 +40,8 @@ port = 39000
 identify_protocol = "/avail_kad/id/1.0.0"
 # Sets agent version that is sent to peers. (default: "avail-light-client/rust-client")
 identify_agent = "avail-light-client/rust-client"
-# Sets the amount of time to keep Kademlia connections alive when they're idle. (default: 30s).
-kad_connection_idle_timeout = 30
+# Sets the amount of time to keep Kademlia connections alive when they're idle. (default: 10s).
+connection_idle_timeout = 10
 # Sets the timeout for a single Kademlia query. (default: 60s).
 kad_query_timeout = 60
 # OpenTelemetry Collector endpoint (default: `http://otelcollector.avail.tools:4317`)

--- a/bootstrap/src/types.rs
+++ b/bootstrap/src/types.rs
@@ -205,7 +205,7 @@ impl Default for RuntimeConfig {
 			autonat_throttle_clients_peer_max: 4,
 			autonat_throttle_clients_period: 1,
 			autonat_only_global_ips: true,
-			connection_idle_timeout: 30,
+			connection_idle_timeout: 10,
 			max_negotiating_inbound_streams: 20,
 			task_command_buffer_size: NonZero::new(30000).unwrap(),
 			per_connection_event_buffer_size: 10000,

--- a/client/README.md
+++ b/client/README.md
@@ -225,8 +225,7 @@ replication_interval = 10800
 # The replication factor determines to how many closest peers a record is replicated. (default: 5).
 replication_factor = 5
 # Sets the amount of time to keep connections alive when they're idle. (default: 30s).
-# NOTE: libp2p default value is 10s, but because of Avail block time of 20s the value has been increased
-connection_idle_timeout = 30
+connection_idle_timeout = 10
 # Sets the timeout for a single Kademlia query. (default: 10s).
 query_timeout = 10
 # Sets the allowed level of parallelism for iterative Kademlia queries. (default: 3).

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.5
 
+- Decrease connection idle timeout to 10s
 - Enforce project name as its own distinct type
 - Update `avail-rust` to the latest version (WASM compatibility updates)
 

--- a/core/src/network/p2p/configuration.rs
+++ b/core/src/network/p2p/configuration.rs
@@ -140,8 +140,7 @@ pub struct LibP2PConfig {
 	pub kademlia: KademliaConfig,
 	/// Vector of Relay nodes, which are used for hole punching
 	pub relays: Vec<MultiaddrConfig>,
-	/// Sets the amount of time to keep connections alive when they're idle. (default: 30s).
-	/// NOTE: libp2p default value is 10s, but because of Avail block time of 20s the value has been increased
+	/// Sets the amount of time to keep connections alive when they're idle. (default: 10s).
 	#[serde(with = "duration_seconds_format")]
 	pub connection_idle_timeout: Duration,
 	pub max_negotiating_inbound_streams: usize,
@@ -164,7 +163,7 @@ impl Default for LibP2PConfig {
 			autonat: Default::default(),
 			kademlia: Default::default(),
 			relays: Default::default(),
-			connection_idle_timeout: Duration::from_secs(30),
+			connection_idle_timeout: Duration::from_secs(10),
 			max_negotiating_inbound_streams: 128,
 			task_command_buffer_size: NonZeroUsize::new(32).unwrap(),
 			per_connection_event_buffer_size: 7,


### PR DESCRIPTION
- Idle connection timeout decreased to from 30s to 10s because of the large number of connections being needlessly kept open 