### PR TITLE
modify `dial_peer` function to allocate new port on each dial

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.5
 
+- Allocate new port on each new dial attempt
+- Set different dial conditions for bootstrap process and diagnostics API
 - Move p2p diagnostics APIs to its own module
 - Decrease connection idle timeout to 10s
 - Enforce project name as its own distinct type

--- a/core/src/api/diagnostics/p2p.rs
+++ b/core/src/api/diagnostics/p2p.rs
@@ -2,7 +2,10 @@ use crate::{
 	api::types::Error,
 	network::p2p::{self, MultiAddressInfo},
 };
-use libp2p::{swarm::DialError, Multiaddr, PeerId};
+use libp2p::{
+	swarm::{dial_opts::PeerCondition, DialError},
+	Multiaddr, PeerId,
+};
 use serde::{Deserialize, Serialize};
 use warp::reply::Reply;
 
@@ -115,7 +118,11 @@ pub async fn dial_external_peer(
 	peer_address: ExternalPeerMultiaddress,
 ) -> Result<ExternalPeerDialResponse, Error> {
 	p2p_client
-		.dial_peer(peer_address.peer_id, vec![peer_address.multiaddress])
+		.dial_peer(
+			peer_address.peer_id,
+			vec![peer_address.multiaddress],
+			PeerCondition::NotDialing,
+		)
 		.await
 		.map(|connection_info| ExternalPeerDialResponse {
 			dial_success: Some(ExternalPeerDialSuccess {


### PR DESCRIPTION
- Allocate new port on each new dial attempt preventing the `Address already in use (os error 48)` type of errors
- Override and set different dial conditions for bootstrap process and diagnostics API 