### PR TITLE
Header timestamp updates

### DIFF
--- a/core/src/api/types.rs
+++ b/core/src/api/types.rs
@@ -345,7 +345,7 @@ pub struct Header {
 	extrinsics_root: H256,
 	extension: Extension,
 	digest: Digest,
-	timestamp: Option<u64>,
+	received_at: Option<u64>,
 }
 
 impl Reply for Header {
@@ -415,7 +415,7 @@ impl Header {
 			extrinsics_root: header.extrinsics_root,
 			extension: header.extension.try_into()?,
 			digest: header.digest.try_into()?,
-			timestamp,
+			received_at: timestamp,
 		})
 	}
 }
@@ -432,7 +432,7 @@ impl TryFrom<AvailHeader> for Header {
 			extrinsics_root: header.extrinsics_root,
 			extension: header.extension.try_into()?,
 			digest: header.digest.try_into()?,
-			timestamp: None,
+			received_at: None,
 		})
 	}
 }
@@ -923,7 +923,7 @@ mod tests {
 				digest: Digest {
 					logs: vec![DigestItem::RuntimeEnvironmentUpdated],
 				},
-				timestamp: Some(
+				received_at: Some(
 					SystemTime::now()
 						.duration_since(UNIX_EPOCH)
 						.unwrap()

--- a/core/src/api/v2/README.md
+++ b/core/src/api/v2/README.md
@@ -168,6 +168,7 @@ Content-Type: application/json
       "{log}", ...
     ]
   },
+  "received_at": "{received-at-timestamp}"
 }
 ```
 
@@ -595,6 +596,7 @@ When header verification is finished, the message is pushed to the light client 
           ]
         }
       }
+      "received_at": "{received-at-timestamp}",
     }
   }
 }

--- a/core/src/api/v2/handlers.rs
+++ b/core/src/api/v2/handlers.rs
@@ -15,7 +15,8 @@ use crate::{
 		},
 	},
 	data::{
-		AppDataKey, BlockHeaderKey, BlockTimestampKey, Database, RpcNodeKey, VerifiedCellCountKey,
+		AppDataKey, BlockHeaderKey, BlockHeaderReceivedAtKey, Database, RpcNodeKey,
+		VerifiedCellCountKey,
 	},
 	utils::calculate_confidence,
 };
@@ -111,8 +112,8 @@ pub async fn block_header(
 		.and_then(|extension| block_status(sync_start_block, db.clone(), block_number, extension))
 		.ok_or(Error::not_found())?;
 
-	let block_timestamp = db
-		.get(BlockTimestampKey(block_number))
+	let received_at = db
+		.get(BlockHeaderReceivedAtKey(block_number))
 		.ok_or_else(Error::not_found)?;
 
 	if matches!(
@@ -124,7 +125,7 @@ pub async fn block_header(
 
 	db.get(BlockHeaderKey(block_number))
 		.ok_or_else(|| eyre!("Header not found"))
-		.and_then(|header| Header::from_avail_header_and_timestamp(header, Some(block_timestamp)))
+		.and_then(|header| (header, received_at).try_into())
 		.map_err(Error::internal_server_error)
 }
 

--- a/core/src/api/v2/mod.rs
+++ b/core/src/api/v2/mod.rs
@@ -217,8 +217,8 @@ mod tests {
 		},
 		data::{
 			self, AchievedConfidenceKey, AchievedSyncConfidenceKey, AppDataKey, BlockHeaderKey,
-			BlockTimestampKey, Database, IsSyncedKey, LatestHeaderKey, LatestSyncKey, MemoryDB,
-			RpcNodeKey, VerifiedCellCountKey, VerifiedDataKey, VerifiedHeaderKey,
+			BlockHeaderReceivedAtKey, Database, IsSyncedKey, LatestHeaderKey, LatestSyncKey,
+			MemoryDB, RpcNodeKey, VerifiedCellCountKey, VerifiedDataKey, VerifiedHeaderKey,
 			VerifiedSyncDataKey,
 		},
 		network::rpc::Node,
@@ -236,12 +236,7 @@ mod tests {
 		AvailHeader, H256,
 	};
 	use hyper::StatusCode;
-	use std::{
-		collections::HashSet,
-		str::FromStr,
-		sync::Arc,
-		time::{SystemTime, UNIX_EPOCH},
-	};
+	use std::{collections::HashSet, str::FromStr, sync::Arc};
 
 	use test_case::test_case;
 	use uuid::Uuid;
@@ -412,13 +407,7 @@ mod tests {
 		db.put(VerifiedHeaderKey, BlockRange::init(9));
 		db.put(LatestSyncKey, 5);
 		db.put(BlockHeaderKey(block_number), header());
-		db.put(
-			BlockTimestampKey(block_number),
-			SystemTime::now()
-				.duration_since(UNIX_EPOCH)
-				.unwrap()
-				.as_secs(),
-		);
+		db.put(BlockHeaderReceivedAtKey(block_number), 1737039274);
 		let route = super::block_header_route(config, db);
 		let response = warp::test::request()
 			.method("GET")
@@ -487,7 +476,7 @@ mod tests {
 		db.put(LatestHeaderKey, 1);
 		db.put(VerifiedHeaderKey, BlockRange::init(1));
 		db.put(BlockHeaderKey(1), header());
-		db.put(BlockTimestampKey(1), 1737039274);
+		db.put(BlockHeaderReceivedAtKey(1), 1737039274);
 		let route = super::block_header_route(config, db);
 		let response = warp::test::request()
 			.method("GET")
@@ -496,7 +485,7 @@ mod tests {
 			.await;
 		assert_eq!(
 			response.body(),
-			r#"{"hash":"0xadf25a1a5d969bb9c9bb9b2e95fe74b0093f0a49ac61e96a1cf41783127f9d1b","parent_hash":"0x0000000000000000000000000000000000000000000000000000000000000000","number":1,"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","extrinsics_root":"0x0000000000000000000000000000000000000000000000000000000000000000","extension":{"rows":0,"cols":0,"data_root":"0x0000000000000000000000000000000000000000000000000000000000000000","commitments":[],"app_lookup":{"size":1,"index":[]}},"digest":{"logs":[]},"timestamp":1737039274}"#
+			r#"{"hash":"0xadf25a1a5d969bb9c9bb9b2e95fe74b0093f0a49ac61e96a1cf41783127f9d1b","parent_hash":"0x0000000000000000000000000000000000000000000000000000000000000000","number":1,"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","extrinsics_root":"0x0000000000000000000000000000000000000000000000000000000000000000","extension":{"rows":0,"cols":0,"data_root":"0x0000000000000000000000000000000000000000000000000000000000000000","commitments":[],"app_lookup":{"size":1,"index":[]}},"digest":{"logs":[]},"received_at":1737039274}"#
 		);
 	}
 

--- a/core/src/crawl_client.rs
+++ b/core/src/crawl_client.rs
@@ -79,6 +79,7 @@ pub async fn run(
 	while let Ok(rpc::OutputEvent::HeaderUpdate {
 		header,
 		received_at,
+		..
 	}) = message_rx.recv().await
 	{
 		let block = match types::BlockVerified::try_from((header, None)) {

--- a/core/src/data.rs
+++ b/core/src/data.rs
@@ -311,9 +311,9 @@ impl RecordKey for SignerNonceKey {
 	}
 }
 
-pub struct BlockTimestampKey(pub u32);
+pub struct BlockHeaderReceivedAtKey(pub u32);
 
-impl RecordKey for BlockTimestampKey {
+impl RecordKey for BlockHeaderReceivedAtKey {
 	type Type = u64;
 
 	fn space(&self) -> Option<&'static str> {
@@ -321,7 +321,7 @@ impl RecordKey for BlockTimestampKey {
 	}
 
 	fn key(&self) -> String {
-		let BlockTimestampKey(block_num) = self;
-		format!("{BLOCK_TIMESTAMP_KEY}:{block_num}")
+		let BlockHeaderReceivedAtKey(block_num) = self;
+		format!("{BLOCK_HEADER_RECEIVED_AT}:{block_num}")
 	}
 }

--- a/core/src/data/keys.rs
+++ b/core/src/data/keys.rs
@@ -35,5 +35,5 @@ pub const CLIENT_ID_KEY: &str = "client_id";
 pub const P2P_KEYPAIR_KEY: &str = "p2p_keypair";
 /// Key for storing signer nonce
 pub const SIGNER_NONCE: &str = "signer_nonce";
-/// Key for storing block timestamp
-pub const BLOCK_TIMESTAMP_KEY: &str = "block_timestamp";
+/// Key for storing block header received at timestamp
+pub const BLOCK_HEADER_RECEIVED_AT: &str = "block_header_received_at";

--- a/core/src/fat_client.rs
+++ b/core/src/fat_client.rs
@@ -249,6 +249,7 @@ pub async fn run(
 				RpcEvent::HeaderUpdate {
 					header,
 					received_at,
+					..
 				} => (header, received_at),
 				// skip ConnectedHost event
 				RpcEvent::ConnectedHost(_) => continue,

--- a/core/src/light_client.rs
+++ b/core/src/light_client.rs
@@ -209,6 +209,7 @@ pub async fn run(
 				RpcEvent::HeaderUpdate {
 					header,
 					received_at,
+					..
 				} => (header, received_at),
 				// skip ConnectedHost event
 				RpcEvent::ConnectedHost(_) => continue,

--- a/core/src/network/rpc.rs
+++ b/core/src/network/rpc.rs
@@ -46,6 +46,7 @@ pub enum OutputEvent {
 	HeaderUpdate {
 		header: AvailHeader,
 		received_at: Instant,
+		received_at_timestamp: u64,
 	},
 }
 


### PR DESCRIPTION
- renamed timestamp to received_at to reduce chance of confusing it with block creation time
- renamed key in database for the same reason
- added timestamp to ws header message
- removed duplicate code 