### PR TITLE
Correct variable name `block_confidence_treshold` → `block_confidence_threshold`

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -80,7 +80,7 @@ impl From<&RuntimeConfig> for AppClientConfig {
 impl From<&RuntimeConfig> for MaintenanceConfig {
 	fn from(val: &RuntimeConfig) -> Self {
 		MaintenanceConfig {
-			block_confidence_treshold: val.confidence,
+			block_confidence_threshold: val.confidence,
 			replication_factor: val.libp2p.kademlia.record_replication_factor.get() as u16,
 			query_timeout: val.libp2p.kademlia.query_timeout,
 			pruning_interval: val.libp2p.kademlia.store_pruning_interval,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -590,12 +590,12 @@ impl ClientState {
 					match maintenance_event {
 						MaintenanceEvent::RecordStats {
 							connected_peers,
-							block_confidence_treshold,
+							block_confidence_threshold,
 							replication_factor,
 							query_timeout,
 						} => {
 							self.metrics.record(MetricValue::DHTConnectedPeers(connected_peers));
-							self.metrics.record(MetricValue::BlockConfidenceThreshold(block_confidence_treshold));
+							self.metrics.record(MetricValue::BlockConfidenceThreshold(block_confidence_threshold));
 							self.metrics.record(MetricValue::DHTReplicationFactor(replication_factor));
 							self.metrics.record(MetricValue::DHTQueryTimeout(query_timeout));
 						},

--- a/core/src/maintenance.rs
+++ b/core/src/maintenance.rs
@@ -12,7 +12,7 @@ use crate::{
 pub enum OutputEvent {
 	RecordStats {
 		connected_peers: usize,
-		block_confidence_treshold: f64,
+		block_confidence_threshold: f64,
 		replication_factor: u16,
 		query_timeout: u32,
 	},
@@ -62,7 +62,7 @@ pub async fn process_block(
 
 	event_sender.send(OutputEvent::RecordStats {
 		connected_peers: peers_num,
-		block_confidence_treshold: maintenance_config.block_confidence_treshold,
+		block_confidence_threshold: maintenance_config.block_confidence_threshold,
 		replication_factor: maintenance_config.replication_factor,
 		query_timeout: maintenance_config.query_timeout.as_secs() as u32,
 	})?;

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -412,7 +412,7 @@ impl Default for AppClientConfig {
 
 #[derive(Clone, Copy)]
 pub struct MaintenanceConfig {
-	pub block_confidence_treshold: f64,
+	pub block_confidence_threshold: f64,
 	pub replication_factor: u16,
 	pub query_timeout: Duration,
 	pub pruning_interval: u32,


### PR DESCRIPTION
- **Updated variable name in `config.rs`**:
  - `block_confidence_treshold` → `block_confidence_threshold`
  
- **Fixed occurrences in `main.rs`, `maintenance.rs`, and `types.rs`**:
  - Updated all references to `block_confidence_treshold` to maintain consistency.
