### PR TITLE
Server monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config*.yaml
 avail_*
 debug.plist
 /identity.toml
+db/

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -624,6 +624,9 @@ impl ClientState {
 									error!("Could not handle Failed PUT Record event properly: {error}");
 								};
 							},
+							P2pEvent::DiscoveredPeers { .. } => {
+
+							}
 						}
 					}
 				Some(maintenance_event) = maintenance_receiver.recv() => {

--- a/core/src/network/p2p.rs
+++ b/core/src/network/p2p.rs
@@ -7,7 +7,7 @@ use configuration::{kad_config, LibP2PConfig};
 use libp2p::{
 	autonat, dcutr, identify,
 	identity::{self, ed25519, Keypair},
-	kad::{self, Mode, PeerRecord, QueryStats, Record, RecordKey},
+	kad::{self, GetClosestPeersResult, Mode, PeerRecord, QueryStats, Record, RecordKey},
 	noise, ping, relay,
 	swarm::NetworkBehaviour,
 	yamux, Multiaddr, PeerId, Swarm, SwarmBuilder,
@@ -99,6 +99,9 @@ pub enum OutputEvent {
 		record_key: RecordKey,
 		query_stats: QueryStats,
 	},
+	DiscoveredPeers {
+		peers: Vec<(PeerId, Vec<Multiaddr>)>,
+	},
 }
 
 #[derive(Clone)]
@@ -167,6 +170,7 @@ impl AgentVersion {
 #[derive(Debug)]
 pub enum QueryChannel {
 	GetRecord(oneshot::Sender<Result<PeerRecord>>),
+	GetClosestPeer(oneshot::Sender<Result<GetClosestPeersResult>>),
 }
 
 type Command = Box<dyn FnOnce(&mut EventLoop) -> Result<(), Report> + Send>;

--- a/core/src/network/p2p/event_loop.rs
+++ b/core/src/network/p2p/event_loop.rs
@@ -8,8 +8,8 @@ use libp2p::{
 	dcutr,
 	identify::{self, Info},
 	kad::{
-		self, store::RecordStore, BootstrapOk, GetRecordOk, InboundRequest, Mode, PutRecordOk,
-		QueryId, QueryResult, RecordKey,
+		self, store::RecordStore, BootstrapOk, GetClosestPeersError, GetClosestPeersOk,
+		GetRecordOk, InboundRequest, Mode, PutRecordOk, QueryId, QueryResult, RecordKey,
 	},
 	multiaddr::Protocol,
 	ping,
@@ -352,6 +352,29 @@ impl EventLoop {
 							},
 							_ => (),
 						},
+						QueryResult::GetClosestPeers(result) => match result {
+							Ok(GetClosestPeersOk { peers, .. }) => {
+								let peer_addresses = collect_peer_addresses(peers);
+
+								if !peer_addresses.is_empty() {
+									let _ = self.event_sender.send(OutputEvent::DiscoveredPeers {
+										peers: peer_addresses,
+									});
+								}
+							},
+							Err(err) => {
+								// There will be peers even though the request timed out
+								let GetClosestPeersError::Timeout { key: _, peers } = err;
+
+								let peer_addresses = collect_peer_addresses(peers);
+
+								if !peer_addresses.is_empty() {
+									let _ = self.event_sender.send(OutputEvent::DiscoveredPeers {
+										peers: peer_addresses,
+									});
+								}
+							},
+						},
 						QueryResult::PutRecord(Err(error)) => {
 							match error {
 								kad::PutRecordError::QuorumFailed { key, .. }
@@ -668,6 +691,18 @@ impl EventLoop {
 			},
 		}
 	}
+}
+
+fn collect_peer_addresses(peers: Vec<kad::PeerInfo>) -> Vec<(PeerId, Vec<Multiaddr>)> {
+	peers
+		.iter()
+		.filter(|peer_info| !peer_info.addrs.is_empty())
+		.map(|peer_info| {
+			let peer_id = peer_info.peer_id;
+			let addresses = peer_info.addrs.clone();
+			(peer_id, addresses)
+		})
+		.collect()
 }
 
 #[cfg(test)]

--- a/monitor-client/src/main.rs
+++ b/monitor-client/src/main.rs
@@ -1,27 +1,44 @@
-use std::time::Duration;
-
-use bootstrap_monitor::BootstrapMonitor;
-use tokio::time;
-
 use avail_light_core::{
 	data,
-	network::p2p::{self},
+	network::p2p::{self, OutputEvent},
 	shutdown::Controller,
 	types::ProjectName,
 	utils::{default_subscriber, json_subscriber, spawn_in_span},
 };
+use bootstrap_monitor::BootstrapMonitor;
 use clap::Parser;
 use color_eyre::{eyre::Context, Result};
-use tracing::{error, info};
+use config::CliOpts;
+use libp2p::{Multiaddr, PeerId};
+use peer_monitor::PeerMonitor;
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::{
+	select,
+	sync::{mpsc::UnboundedReceiver, Mutex},
+	time,
+};
+use tracing::{error, info, trace};
 
 mod bootstrap_monitor;
 mod config;
+mod peer_discovery;
+mod peer_monitor;
+
+#[derive(Clone)]
+pub struct ServerInfo {
+	multiaddr: Vec<Multiaddr>,
+	failed_counter: usize,
+	success_counter: usize,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
+	let server_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>> =
+		Arc::new(Mutex::new(HashMap::default()));
+
 	info!("Starting Avail monitors...");
 	let version = clap::crate_version!();
-
+	let _cli = CliOpts::parse();
 	let opts = config::CliOpts::parse();
 	let config = config::load(&opts)?;
 
@@ -41,7 +58,7 @@ async fn main() -> Result<()> {
 
 	let (p2p_keypair, _) = p2p::identity(&config.libp2p, db.clone())?;
 
-	let (p2p_client, p2p_event_loop, _) = p2p::init(
+	let (p2p_client, p2p_event_loop, p2p_events) = p2p::init(
 		config.libp2p.clone(),
 		ProjectName::new("avail".to_string()),
 		p2p_keypair,
@@ -58,29 +75,101 @@ async fn main() -> Result<()> {
 	spawn_in_span(shutdown.with_cancel(p2p_event_loop.run()));
 
 	let addrs = vec![config.libp2p.tcp_multiaddress()];
-
+	for address in &addrs {
+		info!("Address: {}", address);
+	}
 	p2p_client
 		.start_listening(addrs)
 		.await
 		.wrap_err("Error starting listener.")?;
 	info!("TCP listener started on port {}", config.libp2p.port);
 
-	let interval = time::interval(Duration::from_secs(config.interval));
+	let bootstrap_interval = time::interval(Duration::from_secs(config.bootstrap_interval));
+	let peer_monitor_interval = time::interval(Duration::from_secs(config.peer_monitor_interval));
+	let discovery_interval = time::interval(Duration::from_secs(config.peer_discovery_interval));
+
+	// Start event handler to track discovered peers
+	let server_list_clone = server_list.clone();
+	spawn_in_span(shutdown.with_cancel(async move {
+		if let Err(e) = handle_events(p2p_events, server_list_clone).await {
+			error!("Event handler error: {e}");
+		}
+	}));
 
 	// 1. Test bootstrap availability
-
-	let mut bootstrap_monitor =
-		BootstrapMonitor::new(config.libp2p.bootstraps, interval, p2p_client);
+	let mut bootstrap_monitor = BootstrapMonitor::new(
+		config.libp2p.bootstraps,
+		bootstrap_interval,
+		p2p_client.clone(),
+	);
 	_ = spawn_in_span(shutdown.with_cancel(async move {
 		if let Err(e) = bootstrap_monitor.start_monitoring().await {
 			error!("Bootstrap monitor error: {e}");
 		};
-	}))
-	.await?;
+	}));
 
-	// 2. Test the number of discovered clients from the bootstrap
-	// 3. Test server nodes availability
-	// 4. Test server latencies
+	// peer discovery
+	let peer_discovery = peer_discovery::PeerDiscovery::new(discovery_interval, p2p_client.clone());
+	info!("Starting peer discovery");
+	spawn_in_span(shutdown.with_cancel(async move {
+		if let Err(e) = peer_discovery.start_discovery().await {
+			error!("Peer discovery error: {e}");
+		};
+	}));
 
+	// peer monitor
+	let peer_monitor = PeerMonitor::new(
+		peer_monitor_interval,
+		p2p_client.clone(),
+		server_list.clone(),
+	);
+	info!("Starting monitor part");
+	_ = spawn_in_span(shutdown.with_cancel(async move {
+		if let Err(e) = peer_monitor.start_monitoring().await {
+			error!("Peer monitor error: {e}");
+		};
+	}));
+
+	tokio::signal::ctrl_c().await?;
+	Ok(())
+}
+
+pub async fn handle_events(
+	mut p2p_receiver: UnboundedReceiver<OutputEvent>,
+	server_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>>,
+) -> Result<()> {
+	loop {
+		select! {
+			Some(p2p_event) = p2p_receiver.recv() => {
+				if let OutputEvent::DiscoveredPeers { peers } = p2p_event {
+							trace!("Discovered {} peers", peers.len());
+
+							let mut servers = server_list.lock().await;
+							for (peer_id, addresses) in peers {
+								match servers.get_mut(&peer_id) {
+									Some(info) => {
+										// Addresses are always overriden
+										// TODO: Investigate if we need counter reset on new addresses
+										info.multiaddr = addresses;
+									},
+									None => {
+										let server_info = ServerInfo {
+											multiaddr: addresses,
+											failed_counter: 0,
+											success_counter: 0
+										};
+										servers.insert(peer_id, server_info);
+									}
+								}
+							}
+							info!("Total peers in server list: {}", servers.len());
+						}
+			}
+			else => {
+				info!("Event channel closed, exiting event handler");
+				break;
+			}
+		}
+	}
 	Ok(())
 }

--- a/monitor-client/src/main.rs
+++ b/monitor-client/src/main.rs
@@ -118,11 +118,7 @@ async fn main() -> Result<()> {
 	}));
 
 	// peer monitor
-	let peer_monitor = PeerMonitor::new(
-		peer_monitor_interval,
-		p2p_client.clone(),
-		server_list.clone(),
-	);
+	let peer_monitor = PeerMonitor::new(p2p_client.clone(), peer_monitor_interval, server_list);
 	info!("Starting monitor part");
 	_ = spawn_in_span(shutdown.with_cancel(async move {
 		if let Err(e) = peer_monitor.start_monitoring().await {

--- a/monitor-client/src/main.rs
+++ b/monitor-client/src/main.rs
@@ -1,8 +1,8 @@
 use avail_light_core::{
 	data,
-	network::p2p::{self, OutputEvent},
+	network::p2p::{self, is_multiaddr_global, OutputEvent},
 	shutdown::Controller,
-	types::ProjectName,
+	types::{PeerAddress, ProjectName},
 	utils::{default_subscriber, json_subscriber, spawn_in_span},
 };
 use bootstrap_monitor::BootstrapMonitor;
@@ -11,29 +11,34 @@ use color_eyre::{eyre::Context, Result};
 use config::CliOpts;
 use libp2p::{Multiaddr, PeerId};
 use peer_monitor::PeerMonitor;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, collections::HashSet, sync::Arc, time::Duration};
 use tokio::{
 	select,
 	sync::{mpsc::UnboundedReceiver, Mutex},
 	time,
 };
-use tracing::{error, info, trace};
+use tracing::{debug, error, info, trace};
 
 mod bootstrap_monitor;
 mod config;
 mod peer_discovery;
 mod peer_monitor;
 
-#[derive(Clone)]
+// TODO: Add pruning logic that periodically goes through the list of servers and drops servers that were not seen for a while
+
+#[derive(Clone, Default)]
 pub struct ServerInfo {
 	multiaddr: Vec<Multiaddr>,
 	failed_counter: usize,
 	success_counter: usize,
+	// TODO: Add `last_seen`` timestamp
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
 	let server_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>> =
+		Arc::new(Mutex::new(HashMap::default()));
+	let server_black_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>> =
 		Arc::new(Mutex::new(HashMap::default()));
 
 	info!("Starting Avail monitors...");
@@ -75,14 +80,25 @@ async fn main() -> Result<()> {
 	spawn_in_span(shutdown.with_cancel(p2p_event_loop.run()));
 
 	let addrs = vec![config.libp2p.tcp_multiaddress()];
-	for address in &addrs {
-		info!("Address: {}", address);
-	}
 	p2p_client
 		.start_listening(addrs)
 		.await
 		.wrap_err("Error starting listener.")?;
 	info!("TCP listener started on port {}", config.libp2p.port);
+
+	// Extract bootstrap peer IDs
+	// These are tracked with the bootstrap monitor, not with server monitor
+	let bootstrap_peers: HashSet<PeerId> = config
+		.libp2p
+		.bootstraps
+		.iter()
+		.filter_map(|peer_addr| match peer_addr {
+			PeerAddress::PeerIdAndMultiaddr((peer_id, _)) => Some(*peer_id),
+			_ => None,
+		})
+		.collect();
+
+	info!("Bootstrap peers: {:?}", bootstrap_peers);
 
 	let bootstrap_interval = time::interval(Duration::from_secs(config.bootstrap_interval));
 	let peer_monitor_interval = time::interval(Duration::from_secs(config.peer_monitor_interval));
@@ -90,8 +106,17 @@ async fn main() -> Result<()> {
 
 	// Start event handler to track discovered peers
 	let server_list_clone = server_list.clone();
+	let server_black_list_clone = server_black_list.clone();
+	let bootstrap_peers_clone = bootstrap_peers.clone();
 	spawn_in_span(shutdown.with_cancel(async move {
-		if let Err(e) = handle_events(p2p_events, server_list_clone).await {
+		if let Err(e) = handle_events(
+			p2p_events,
+			server_list_clone,
+			server_black_list_clone,
+			bootstrap_peers_clone,
+		)
+		.await
+		{
 			error!("Event handler error: {e}");
 		}
 	}));
@@ -133,6 +158,8 @@ async fn main() -> Result<()> {
 pub async fn handle_events(
 	mut p2p_receiver: UnboundedReceiver<OutputEvent>,
 	server_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>>,
+	server_black_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>>,
+	bootstrap_peers: HashSet<PeerId>,
 ) -> Result<()> {
 	loop {
 		select! {
@@ -141,12 +168,37 @@ pub async fn handle_events(
 							trace!("Discovered {} peers", peers.len());
 
 							let mut servers = server_list.lock().await;
+							let mut black_list = server_black_list.lock().await;
 							for (peer_id, addresses) in peers {
+								if bootstrap_peers.contains(&peer_id) {
+									trace!("Skipping bootstrap peer {}", peer_id);
+									continue;
+								}
+
+								let globally_reachable_addresses: Vec<Multiaddr> = addresses
+									.iter()
+									.filter(|addr| is_multiaddr_global(addr))
+									.cloned()
+									.collect();
+
+								if globally_reachable_addresses.is_empty() {
+									debug!("Peer {} has no globally reachable addresses, adding to blacklist", peer_id);
+									black_list.entry(peer_id).or_insert_with(ServerInfo::default);
+									continue;
+								}
+
+								// A new global address just appeared for the peer that previously had none
+								if let Some(peer) = black_list.get(&peer_id) {
+									if peer.multiaddr.is_empty() {
+										trace!("Peer {} now has globally reachable addresses, removing from blacklist", peer_id);
+										black_list.remove(&peer_id);
+									}
+								}
+
 								match servers.get_mut(&peer_id) {
 									Some(info) => {
-										// Addresses are always overriden
-										// TODO: Investigate if we need counter reset on new addresses
 										info.multiaddr = addresses;
+										// We don't reset counters here because even though the addresses might be new, servers can still continue to fail (if they started failing previously)
 									},
 									None => {
 										let server_info = ServerInfo {

--- a/monitor-client/src/peer_discovery.rs
+++ b/monitor-client/src/peer_discovery.rs
@@ -1,0 +1,38 @@
+//use std::time::Duration;
+
+use avail_light_core::network::p2p::Client;
+use color_eyre::Result;
+use libp2p::PeerId;
+use tokio::time::Interval;
+use tracing::{trace, warn};
+
+pub struct PeerDiscovery {
+	interval: Interval,
+	p2p_client: Client,
+}
+
+impl PeerDiscovery {
+	pub fn new(interval: Interval, p2p_client: Client) -> Self {
+		Self {
+			interval,
+			p2p_client,
+		}
+	}
+
+	// Periodically dispatches closest peers query for a randomly generated peer id
+	// Generated peer ids (should) follow a uniform distribution
+	pub async fn start_discovery(mut self) -> Result<()> {
+		loop {
+			self.interval.tick().await;
+
+			let random_peer_id = PeerId::random();
+			trace!("Firing for peer: {}", random_peer_id);
+			match self.p2p_client.get_closest_peers(random_peer_id).await {
+				Ok(_) => {},
+				Err(e) => {
+					warn!("Failed to initiate query: {}", e);
+				},
+			}
+		}
+	}
+}

--- a/monitor-client/src/peer_monitor.rs
+++ b/monitor-client/src/peer_monitor.rs
@@ -100,8 +100,9 @@ async fn check_peer_connectivity(
 	peer_id: &PeerId,
 	info: &mut ServerInfo,
 ) -> Result<()> {
+	// NOTE: `PeerCondition::NotDialing` might not be the best suitable dial condition for our approach
 	match p2p_client
-		.dial_peer(*peer_id, info.multiaddr.clone(), PeerCondition::Always)
+		.dial_peer(*peer_id, info.multiaddr.clone(), PeerCondition::NotDialing)
 		.await
 	{
 		Ok(_) => {

--- a/monitor-client/src/peer_monitor.rs
+++ b/monitor-client/src/peer_monitor.rs
@@ -1,0 +1,94 @@
+//! LibP2P reachability monitor
+//!
+//! The monitor periodically dials all of the peers from the `server_list` and saves
+//!
+//! - externally unreachable peers
+//! - peers without a public address (which are also externally unreachable)
+use color_eyre::Result;
+use libp2p::{swarm::dial_opts::PeerCondition, PeerId};
+use std::{collections::HashMap, sync::Arc};
+use tokio::{sync::Mutex, time::Interval};
+use tracing::{debug, info, warn};
+
+use avail_light_core::network::p2p::Client;
+
+use crate::ServerInfo;
+
+pub struct PeerMonitor {
+	interval: Interval,
+	p2p_client: Client,
+	server_monitor_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>>,
+	server_black_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>>,
+}
+
+impl PeerMonitor {
+	pub fn new(interval: Interval, p2p_client: Client) -> Self {
+		Self {
+			interval,
+			p2p_client,
+			server_monitor_list: Default::default(),
+			server_black_list: Default::default(),
+		}
+	}
+
+	pub async fn start_monitoring(mut self) -> Result<()> {
+		info!("Peer monitoring started");
+
+		loop {
+			self.interval.tick().await;
+			if let Err(e) = self.process_peers().await {
+				warn!("Error processing peers: {}", e);
+			}
+		}
+	}
+
+	async fn process_peers(&mut self) -> Result<()> {
+		let mut server_list = self.server_monitor_list.lock().await;
+		for (peer_id, info) in server_list.iter_mut() {
+			tokio::spawn(check_peer_connectivity(
+				self.p2p_client.clone(),
+				self.server_black_list.clone(),
+				peer_id,
+				info,
+			));
+		}
+
+		Ok(())
+	}
+}
+
+async fn check_peer_connectivity(
+	p2p_client: Client,
+	server_black_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>>,
+	peer_id: &PeerId,
+	info: &mut ServerInfo,
+) -> Result<()> {
+	match p2p_client
+		.dial_peer(*peer_id, info.multiaddr.clone(), PeerCondition::NotDialing)
+		.await
+	{
+		Ok(_) => {
+			debug!("✅ Successfully dialed peer {}", peer_id);
+			info.success_counter += 1;
+			info.failed_counter = 0;
+			// TODO: If blacklisted and started being reachable, remove from the blacklist after a threshold of succesful dials
+		},
+		Err(e) => {
+			debug!("❌ Failed to dial peer {}: {}", peer_id, e);
+			info.failed_counter += 1;
+			// TODO: Parametarize failed counter threshold
+			if info.failed_counter >= 3 {
+				warn!(
+					"⚠️ Peer {} has been unreachable for 3 consecutive attempts!",
+					peer_id
+				);
+				server_black_list
+					.lock()
+					.await
+					.insert(*peer_id, info.clone());
+			}
+		},
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
- implement peer discovery using Kademlia random walk
- add server monitoring by periodically dialing discovered peers
- maintain a server blacklist with servers that failed dials for N consecutive dials