### PR TITLE
chore: fix typos and quotation marks

### DIFF
--- a/core/src/api/diagnostics/README.md
+++ b/core/src/api/diagnostics/README.md
@@ -38,7 +38,7 @@ Content-Type: application/json
 
 ## **POST** `/v1/p2p/peers/dial`
 
-Dials a peer on the light client P2P network and waits for it's response.
+Dials a peer on the light client P2P network and waits for its response.
 If the dial goes through, a 200 OK response, the example JSON is stated below.
 
 If an error occurs on the dial 3 types of responses can be returned:

--- a/core/src/api/v2/README.md
+++ b/core/src/api/v2/README.md
@@ -199,7 +199,7 @@ Content-Type: application/json
 ```
 
 If **block_status** is **incomplete**, data will be empty.
-If **block_status** is not **“finished”**, or **app** mode is not enabled, data is not available and the response is:
+If **block_status** is not **"finished"**, or **app** mode is not enabled, data is not available and the response is:
 
 ```yaml
 HTTP/1.1 400 Bad Request
@@ -210,7 +210,7 @@ HTTP/1.1 400 Bad Request
 Submits application data to the avail network.\
 In case of `data` transaction, data transaction is created, signed and submitted.\
 In case of `extrinsic`, externally created and signed transaction is submitted. Only one field is allowed per request.\
-Both `data` and `extrinsic` has to be encoded using base64 encoding.
+Both `data` and `extrinsic` have to be encoded using base64 encoding.
 
 Request:
 
@@ -286,7 +286,7 @@ Content-Type: application/json
 
 ## **POST** `/v2/p2p/peers/dial`
 
-Dials a peer on the light client P2P network and waits for it's response.
+Dials a peer on the light client P2P network and waits for its response.
 If the dial goes through, a 200 OK response, the example JSON is stated below.
 
 If an error occurs on the dial 3 types of responses can be returned:

--- a/core/src/fat_client.rs
+++ b/core/src/fat_client.rs
@@ -3,7 +3,7 @@
 //! # Flow
 //!
 //! * Fetches assigned block partition when finalized header is available and
-//! * inserts data rows and cells to to DHT for remote fetch.
+//! * inserts data rows and cells to DHT for remote fetch.
 //!
 //! # Notes
 //!

--- a/core/src/light_client.rs
+++ b/core/src/light_client.rs
@@ -9,7 +9,7 @@
 //! * Retrieve cell proofs from a) DHT and/or b) via RPC call from the node, in that order
 //! * Verify proof using the received cells
 //! * Calculate block confidence and store it in RocksDB
-//! * Insert cells to to DHT for remote fetch
+//! * Insert cells to DHT for remote fetch
 //! * Notify the consumer (app client) a new block has been verified
 //!
 //! # Notes

--- a/core/src/network/rpc/subscriptions.rs
+++ b/core/src/network/rpc/subscriptions.rs
@@ -199,7 +199,7 @@ impl<T: Database + Clone> SubscriptionLoop<T> {
 					finality_synced = self.db.get(IsFinalitySyncedKey).unwrap_or(false)
 				}
 
-				// try and get get all the skipped blocks, if they exist
+				// try and get all the skipped blocks, if they exist
 				if let Some(last_header) = self.block_data.last_finalized_block_header.as_ref() {
 					for bl_num in (last_header.number + 1)..header.number {
 						info!("Sending skipped block {bl_num}");

--- a/core/src/sync_client.rs
+++ b/core/src/sync_client.rs
@@ -9,7 +9,7 @@
 //! * Retrieve cell proofs from a) DHT and/or b) via RPC call from the node, in that order
 //! * Verify proof using the received cells
 //! * Calculate block confidence and store it in RocksDB
-//! * Insert cells to to DHT for remote fetch
+//! * Insert cells to DHT for remote fetch
 //!
 //! # Notes
 //!

--- a/relay/README.md
+++ b/relay/README.md
@@ -9,7 +9,7 @@
 
 `avail-light-relay` is a server node, which utilizes Circuit Relay transport protocol.
 
-This node routes traffic between two peers as a third-party “relay” peer.
+This node routes traffic between two peers as a third-party "relay" peer.
 
 In peer-to-peer networks, on the whole, there will come a time when peers will be unable to traverse their NAT and/or firewalls. Which makes them publicly unavailable. To face these connectivity hurdles, when a peer isn't able to listen to a public address, it can dial out to a relay peer, which will retain a long-lived open connection.
 
@@ -21,7 +21,7 @@ All participants are identified using their Peer ID, including the relay node, w
 
 ## Address
 
-A relay node is identified using a multiaddr that includes the Peer ID of the peer whose traffic is being relayed (the listening peer or “relay target”). With this in mind, we could construct an address that describes a path to the source through some specific relay with selected transport:
+A relay node is identified using a multiaddr that includes the Peer ID of the peer whose traffic is being relayed (the listening peer or "relay target"). With this in mind, we could construct an address that describes a path to the source through some specific relay with selected transport:
 
 `/ip4/198.51.100.0/tcp/55555/p2p/SomeRelay/p2p-circuit/p2p/SomeDude`
 


### PR DESCRIPTION
Some editors may not accurately render unexpected characters, appearing as gibberish or causing formatting problems.