### PR TITLE
fix: Temp removes aarch64 builds

### DIFF
--- a/.github/workflows/avail-light-crawler.yml
+++ b/.github/workflows/avail-light-crawler.yml
@@ -21,16 +21,6 @@ jobs:
             extra_setup: |
               rustup target add x86_64-unknown-linux-gnu
 
-          - os: ubuntu-22.04
-            workspace: avail-light-crawler
-            rust_target: aarch64-unknown-linux-gnu
-            output_name: avail-light-linux-arm64
-            extra_setup: |
-              sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-              rustup target add aarch64-unknown-linux-gnu
-              export BINDGEN_EXTRA_CLANG_ARGS='--sysroot /usr/aarch64-linux-gnu'
-              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc
-
           - os: macos-14
             workspace: avail-light-crawler
             rust_target: aarch64-apple-darwin

--- a/.github/workflows/avail-light-fatclient.yml
+++ b/.github/workflows/avail-light-fatclient.yml
@@ -20,16 +20,6 @@ jobs:
             extra_setup: |
               rustup target add x86_64-unknown-linux-gnu
 
-          - os: ubuntu-22.04
-            workspace: avail-light-fat
-            rust_target: aarch64-unknown-linux-gnu
-            output_name: avail-light-linux-arm64
-            extra_setup: |
-              sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-              rustup target add aarch64-unknown-linux-gnu
-              export BINDGEN_EXTRA_CLANG_ARGS='--sysroot /usr/aarch64-linux-gnu'
-              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc
-
           - os: macos-14
             workspace: avail-light-fat
             rust_target: aarch64-apple-darwin


### PR DESCRIPTION
# Change
- [x] Temp removes aarch64 builds


## Reason for Change

- `openssl-sys v0.9.105` crate [fails](https://github.com/availproject/avail-light/actions/runs/14352991456/job/40235902329) to build on `arm64` due to missing runner OS `openssl` config. Needs to remove this build for the time being in order to unblock other builds/features. We still need to troubleshoot and fix it in the long run.

This change relates to:
- https://github.com/availproject/avail-light/pull/790