### PR TITLE
Libp2p timeout tuning

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -171,16 +171,6 @@ secret_key = { seed={seed} }
 port = 37000
 # P2P WebRTC listener port (default: 37001).
 webrtc_port = 37001
-# Configures AutoNAT behaviour to reject probes as a server for clients that are observed at a non-global ip address (default: false)
-autonat_only_global_ips = false
-# AutoNat throttle period for re-using a peer as server for a dial-request. (default: 1s)
-autonat_throttle = 2
-# Interval in which the NAT status should be re-tried if it is currently unknown or max confidence was not reached yet. (default: 20s)
-autonat_retry_interval = 20
-# Interval in which the NAT should be tested again if max confidence was reached in a status. (default: 360s)
-autonat_refresh_interval = 360
-# AutoNat on init delay before starting the first probe. (default: 5s)
-autonat_boot_delay = 10
 # Vector of Light Client bootstrap nodes, used to bootstrap the DHT (mandatory field).
 bootstraps = ["/ip4/13.51.79.255/tcp/39000/p2p/12D3KooWE2xXc6C2JzeaCaEg7jvZLogWyjLsB5dA3iw5o3KcF9ds"]
 # Vector of Relay nodes, which are used for hole punching

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.7
 
+- Updated the default AutoNat configuration with increased timeouts
 - Added counters for initial and switched RPC host connections to telemetry metrics
 - Added put records counter to telemetry metrics
 - Removed retry strategy from the Subxt Avail client

--- a/core/src/network/p2p/configuration.rs
+++ b/core/src/network/p2p/configuration.rs
@@ -17,16 +17,16 @@ use web_time::Duration;
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(default)]
 pub struct AutoNATConfig {
-	/// Interval in which the NAT status should be re-tried if it is currently unknown or max confidence was not reached yet. (default: 20 sec)
+	/// Interval in which the NAT status should be re-tried if it is currently unknown or max confidence was not reached yet. (default: 90 sec)
 	#[serde(with = "duration_seconds_format")]
 	pub autonat_retry_interval: Duration,
-	/// Interval in which the NAT should be tested again if max confidence was reached in a status. (default: 360 sec)
+	/// Interval in which the NAT should be tested again if max confidence was reached in a status. (default: 900 sec)
 	#[serde(with = "duration_seconds_format")]
 	pub autonat_refresh_interval: Duration,
-	/// AutoNat on init delay before starting the fist probe. (default: 5 sec)
+	/// AutoNat on init delay before starting the fist probe. (default: 15 sec)
 	#[serde(with = "duration_seconds_format")]
 	pub autonat_boot_delay: Duration,
-	/// AutoNat throttle period for re-using a peer as server for a dial-request. (default: 1 sec)
+	/// AutoNat throttle period for re-using a peer as server for a dial-request. (default: 90 sec)
 	#[serde(with = "duration_seconds_format")]
 	pub autonat_throttle: Duration,
 	/// Configures AutoNAT behaviour to reject probes as a server for clients that are observed at a non-global ip address (default: false)
@@ -36,10 +36,10 @@ pub struct AutoNATConfig {
 impl Default for AutoNATConfig {
 	fn default() -> Self {
 		Self {
-			autonat_retry_interval: Duration::from_secs(20),
-			autonat_refresh_interval: Duration::from_secs(360),
-			autonat_boot_delay: Duration::from_secs(5),
-			autonat_throttle: Duration::from_secs(1),
+			autonat_retry_interval: Duration::from_secs(90),
+			autonat_refresh_interval: Duration::from_secs(15 * 60),
+			autonat_boot_delay: Duration::from_secs(15),
+			autonat_throttle: Duration::from_secs(90),
 			autonat_only_global_ips: false,
 		}
 	}


### PR DESCRIPTION
- update the default AutoNat configuration with the increased timeouts