### PR TITLE
Enable libp2p metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parity-scale-codec",
  "pcap",
+ "prometheus-client",
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ confy = "0.5.1"
 hex = "0.4.3"
 rand = { version = "0.8.5", default-features = false }
 reqwest = { version = "0.12" }
-libp2p = { version = "0.55.0", features = ["kad", "identify", "ping", "autonat", "relay", "dcutr", "noise", "yamux", "dns", "metrics", "tokio", "macros", "tcp", "quic", "serde", "websocket"] }
+libp2p = { version = "0.55.0", features = ["kad", "identify", "ping", "autonat", "relay", "dcutr", "noise", "yamux", "dns", "metrics", "tokio", "macros", "tcp", "quic", "serde", "websocket", "metrics"] }
 libp2p-allow-block-list = "0.5.0"
 libp2p-webrtc-websys = "0.4.0"
 multihash = { version = "0.14.0", default-features = false, features = ["blake3", "sha3"] }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -80,7 +80,7 @@ async fn run(
 
 	let (id_keys, peer_id) = p2p::identity(&cfg.libp2p, db.clone())?;
 
-	let (p2p_client, p2p_event_loop, p2p_event_receiver) = p2p::init(
+	let (p2p_client, p2p_event_loop, p2p_event_receiver, registry) = p2p::init(
 		cfg.libp2p.clone(),
 		cfg.project_name.clone(),
 		id_keys,
@@ -199,6 +199,7 @@ async fn run(
 		ws_clients: ws_clients.clone(),
 		shutdown: shutdown.clone(),
 		p2p_client: p2p_client.clone(),
+		metric_registry: registry.clone(),
 	};
 	spawn_in_span(shutdown.with_cancel(server.bind(cfg.api.clone())));
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,6 +29,8 @@ itertools = "0.10.5"
 libp2p-allow-block-list = { workspace = true }
 mockall = "0.11.3"
 once_cell = "1.20.3"
+# NOTE: Specified version must match libp2p version
+prometheus-client = "=0.22.3"
 regex = "1.11.1"
 reqwest = { workspace = true, features = ["json"] }
 semver = { workspace = true }

--- a/core/src/network/p2p/configuration.rs
+++ b/core/src/network/p2p/configuration.rs
@@ -157,6 +157,8 @@ pub struct LibP2PConfig {
 	pub bootstraps: Vec<PeerAddress>,
 	/// Maximum number of parallel tasks spawned for GET and PUT operations on DHT (default: 20).
 	pub dht_parallelization_limit: usize,
+	/// Enable metrics collection (default: false)
+	pub metrics: bool,
 }
 
 impl Default for LibP2PConfig {
@@ -176,6 +178,7 @@ impl Default for LibP2PConfig {
 			dial_concurrency_factor: NonZeroU8::new(8).unwrap(),
 			bootstraps: vec![],
 			dht_parallelization_limit: 20,
+			metrics: false,
 		}
 	}
 }

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -64,6 +64,8 @@ impl MetricCounter {
 			MetricCounter::IncomingGetRecord,
 			MetricCounter::EventLoopEvent,
 			MetricCounter::DHTPutRecords,
+			MetricCounter::RpcConnected,
+			MetricCounter::RpcConnectionSwitched,
 		]
 	}
 

--- a/crawler/src/main.rs
+++ b/crawler/src/main.rs
@@ -83,7 +83,7 @@ async fn run(config: Config, db: DB, shutdown: Controller<String>) -> Result<()>
 	let partition = config.crawl_block_matrix_partition;
 	let partition_size = format!("{}/{}", partition.number, partition.fraction);
 
-	let (p2p_client, p2p_event_loop, p2p_event_receiver) = p2p::init(
+	let (p2p_client, p2p_event_loop, p2p_event_receiver, _) = p2p::init(
 		config.libp2p.clone(),
 		ProjectName::new("avail".to_string()),
 		p2p_keypair,

--- a/fat/src/main.rs
+++ b/fat/src/main.rs
@@ -89,7 +89,7 @@ async fn run(config: Config, db: DB, shutdown: Controller<String>) -> Result<()>
 	let partition_size = format!("{}/{}", partition.number, partition.fraction);
 	let identity_cfg = IdentityConfig::from_suri("//Alice".to_string(), None)?;
 
-	let (p2p_client, p2p_event_loop, p2p_event_receiver) = p2p::init(
+	let (p2p_client, p2p_event_loop, p2p_event_receiver, _) = p2p::init(
 		config.libp2p.clone(),
 		ProjectName::new("avail".to_string()),
 		p2p_keypair,
@@ -185,6 +185,7 @@ async fn run(config: Config, db: DB, shutdown: Controller<String>) -> Result<()>
 		ws_clients: ws_clients.clone(),
 		shutdown: shutdown.clone(),
 		p2p_client: p2p_client.clone(),
+		metric_registry: None,
 	};
 	spawn_in_span(shutdown.with_cancel(server.bind(config.api.clone())));
 

--- a/monitor-client/src/main.rs
+++ b/monitor-client/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
 
 	let (p2p_keypair, _) = p2p::identity(&config.libp2p, db.clone())?;
 
-	let (p2p_client, p2p_event_loop, p2p_events) = p2p::init(
+	let (p2p_client, p2p_event_loop, p2p_events, _) = p2p::init(
 		config.libp2p.clone(),
 		ProjectName::new("avail".to_string()),
 		p2p_keypair,


### PR DESCRIPTION
Example of available metrics:
```
libp2p_bandwidth_bytes_total{protocols="/dns/tcp/p2p",direction="Outbound"} 744
libp2p_bandwidth_bytes_total{protocols="/ip4/tcp",direction="Outbound"} 3470570
libp2p_bandwidth_bytes_total{protocols="/ip4/tcp/p2p",direction="Outbound"} 6107958
libp2p_bandwidth_bytes_total{protocols="/ip4/tcp/p2p",direction="Inbound"} 984521
libp2p_bandwidth_bytes_total{protocols="/ip4/tcp",direction="Inbound"} 861639
libp2p_bandwidth_bytes_total{protocols="/dns/tcp/p2p",direction="Inbound"} 4713
```