### PR TITLE
Monitor tool rest api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,189 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags 2.8.0",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dfe5c9e0004c623edc65391dfd51daa201e7e30ebd9c9bedf873048ec32bc2"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "base64 0.22.1",
+ "bitflags 2.8.0",
+ "brotli",
+ "bytes",
+ "bytestring",
+ "derive_more 2.0.1",
+ "encoding_rs",
+ "flate2",
+ "foldhash",
+ "futures-core",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.9.0",
+ "sha1",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zstd 0.13.3",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+dependencies = [
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
+dependencies = [
+ "bytestring",
+ "cfg-if 1.0.0",
+ "http 0.2.12",
+ "regex",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a597b77b5c6d6a1e1097fddde329a83665e25c5437c696a3a9a4aa514a614dea"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "bytes",
+ "bytestring",
+ "cfg-if 1.0.0",
+ "cookie",
+ "derive_more 2.0.1",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +297,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -1282,11 +1480,13 @@ dependencies = [
 name = "avail-light-monitor"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
  "avail-light-core",
  "clap",
  "color-eyre",
  "libp2p",
  "serde",
+ "serde_json",
  "statrs",
  "tokio",
  "tracing",
@@ -2031,6 +2231,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,6 +2300,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -2504,6 +2734,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -3354,7 +3595,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -3362,6 +3612,18 @@ name = "derive_more-impl"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5579,6 +5841,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
 name = "impl-num-traits"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6078,6 +6346,12 @@ checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -6810,6 +7084,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "local-channel"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7086,6 +7377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -7569,9 +7861,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -11237,6 +11529,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -15127,14 +15425,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/monitor-client/Cargo.toml
+++ b/monitor-client/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2021"
 repository.workspace = true
 
 [dependencies]
+actix-web = "4.11.0"
 avail-light-core = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 libp2p = { workspace = true }
 serde = { workspace = true }
+serde_json = "1.0"
 statrs = "0.16.0"
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/monitor-client/src/config.rs
+++ b/monitor-client/src/config.rs
@@ -59,6 +59,38 @@ pub struct CliOpts {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(default)]
+pub struct PaginationConfig {
+	pub default_page: usize,
+	pub default_limit: usize,
+	pub min_page: usize,
+	pub min_limit: usize,
+	pub max_limit: usize,
+}
+
+impl Default for PaginationConfig {
+	fn default() -> Self {
+		Self {
+			default_page: 1,
+			default_limit: 50,
+			min_page: 1,
+			min_limit: 1,
+			max_limit: 100,
+		}
+	}
+}
+
+impl PaginationConfig {
+	pub fn validate_page(&self, page: usize) -> usize {
+		page.max(self.min_page)
+	}
+
+	pub fn validate_limit(&self, limit: usize) -> usize {
+		limit.clamp(self.min_limit, self.max_limit)
+	}
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
 pub struct Config {
 	/// Genesis hash of the network to be connected to.
 	/// Set to "DEV" to connect to any network.
@@ -80,6 +112,8 @@ pub struct Config {
 	pub libp2p: LibP2PConfig,
 	pub fail_threshold: usize,
 	pub success_threshold: usize,
+	pub http_port: Option<u16>,
+	pub pagination: PaginationConfig,
 }
 
 impl Default for Config {
@@ -95,6 +129,8 @@ impl Default for Config {
 			peer_monitor_interval: 30,
 			fail_threshold: 3,
 			success_threshold: 3,
+			http_port: Some(3030),
+			pagination: PaginationConfig::default(),
 		}
 	}
 }

--- a/monitor-client/src/main.rs
+++ b/monitor-client/src/main.rs
@@ -147,22 +147,6 @@ async fn main() -> Result<()> {
 		};
 	}));
 
-	// let server_list_clone = server_list.clone();
-	// let server_black_list_clone = server_black_list.clone();
-	// let config_pagination = config.pagination.clone();
-	// spawn_in_span(shutdown.with_cancel(async move {
-	// 	if let Err(e) = server::start_server(
-	// 		server_black_list_clone,
-	// 		server_list_clone,
-	// 		config_pagination,
-	// 		config.http_port.unwrap(),
-	// 	)
-	// 	.await
-	// 	{
-	// 		error!("HTTP server error: {e}");
-	// 	}
-	// }));
-
 	// peer monitor
 	let config_clone = config.clone();
 	let peer_monitor = PeerMonitor::new(

--- a/monitor-client/src/server.rs
+++ b/monitor-client/src/server.rs
@@ -16,7 +16,7 @@ pub struct PeerInfo {
 	multiaddr: Vec<String>,
 	last_discovered: Option<u64>,
 	last_successful_dial: Option<u64>,
-	average_ping_ms: Option<f64>,
+	average_ping_ms: Option<u128>,
 	last_ping_rtt: Option<Duration>,
 }
 
@@ -120,7 +120,7 @@ async fn get_peers(
 			let (avg_ping_ms, last_ping) = if is_blacklisted {
 				(None, None)
 			} else {
-				(info.avg_ping().map(|d| d.as_secs_f64()), info.last_ping_rtt)
+				(info.avg_ping().map(|d| d.as_millis()), info.last_ping_rtt)
 			};
 			(
 				peer_id.to_string(),

--- a/monitor-client/src/server.rs
+++ b/monitor-client/src/server.rs
@@ -1,0 +1,256 @@
+use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
+use libp2p::PeerId;
+use serde::{Deserialize, Serialize};
+use std::{
+	collections::HashMap,
+	net::{Ipv4Addr, SocketAddr},
+	sync::Arc,
+	time::{Duration, SystemTime},
+};
+use tokio::sync::Mutex;
+use tracing::{error, info};
+
+use crate::{config::PaginationConfig, types::ServerInfo};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PeerInfo {
+	peer_id: String,
+	multiaddr: Vec<String>,
+	last_discovered: Option<u64>,
+	last_successful_dial: Option<u64>,
+	average_ping_ms: Option<f64>,
+	last_ping_rtt: Option<Duration>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PeerCounts {
+	server_list_count: usize,
+	blacklist_count: usize,
+}
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PaginatedResponse<T> {
+	total_items: usize,
+	total_pages: usize,
+	current_page: usize,
+	page_size: usize,
+	next_page: Option<String>,
+	prev_page: Option<String>,
+	data: T,
+}
+
+#[derive(Deserialize)]
+pub struct PaginationParams {
+	#[serde(default = "default_page")]
+	pub page: usize,
+	#[serde(default = "default_limit")]
+	pub limit: usize,
+}
+
+fn default_page() -> usize {
+	1
+}
+
+fn default_limit() -> usize {
+	50
+}
+
+pub struct AppState {
+	pub blacklist: Arc<Mutex<HashMap<PeerId, ServerInfo>>>,
+	pub server_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>>,
+	pub config_pagination: PaginationConfig,
+}
+
+#[get("/blacklisted_peers")]
+async fn get_blacklisted_peers(
+	app_state: web::Data<AppState>,
+	pagination: web::Query<PaginationParams>,
+) -> impl Responder {
+	let blacklist = app_state.blacklist.lock().await;
+
+	let page = app_state.config_pagination.validate_page(pagination.page);
+	let limit = app_state.config_pagination.validate_limit(pagination.limit);
+
+	let peers: Vec<(String, PeerInfo)> = blacklist
+		.iter()
+		.map(|(peer_id, info)| {
+			let peer_id_str = peer_id.to_string();
+
+			let peer_info = PeerInfo {
+				peer_id: peer_id_str.clone(),
+				multiaddr: info.multiaddr.iter().map(|addr| addr.to_string()).collect(),
+				last_discovered: info.last_discovered.map(|time| {
+					time.duration_since(SystemTime::UNIX_EPOCH)
+						.unwrap_or_default()
+						.as_secs()
+				}),
+				last_successful_dial: info.last_successful_dial.map(|time| {
+					time.duration_since(SystemTime::UNIX_EPOCH)
+						.unwrap_or_default()
+						.as_secs()
+				}),
+				last_ping_rtt: None,
+				average_ping_ms: None,
+			};
+
+			(peer_id_str, peer_info)
+		})
+		.collect();
+
+	let mut sorted_peers = peers;
+	sorted_peers.sort_by(|a, b| a.0.cmp(&b.0));
+
+	let response = paginate_as_array(sorted_peers, page, limit, "/blacklisted_peers");
+
+	HttpResponse::Ok().json(response)
+}
+
+#[get("/peers")]
+async fn get_peers(
+	app_state: web::Data<AppState>,
+	pagination: web::Query<PaginationParams>,
+) -> impl Responder {
+	let page = app_state.config_pagination.validate_page(pagination.page);
+	let limit = app_state.config_pagination.validate_limit(pagination.limit);
+
+	let server_list = app_state.server_list.lock().await;
+	let blacklist = app_state.blacklist.lock().await;
+
+	let server_peers: Vec<(String, PeerInfo)> = server_list
+		.iter()
+		.map(|(peer_id, info)| {
+			let is_blacklisted = blacklist.contains_key(peer_id);
+			let (avg_ping_ms, last_ping) = if is_blacklisted {
+				(None, None)
+			} else {
+				(info.avg_ping().map(|d| d.as_secs_f64()), info.last_ping_rtt)
+			};
+			(
+				peer_id.to_string(),
+				PeerInfo {
+					peer_id: peer_id.to_string(),
+					multiaddr: info.multiaddr.iter().map(|addr| addr.to_string()).collect(),
+					last_discovered: info.last_discovered.map(|time| {
+						time.duration_since(SystemTime::UNIX_EPOCH)
+							.unwrap_or_default()
+							.as_secs()
+					}),
+					last_successful_dial: info.last_successful_dial.map(|time| {
+						time.duration_since(SystemTime::UNIX_EPOCH)
+							.unwrap_or_default()
+							.as_secs()
+					}),
+					average_ping_ms: avg_ping_ms,
+					last_ping_rtt: last_ping,
+				},
+			)
+		})
+		.collect();
+	let mut sorted_peers = server_peers;
+	sorted_peers.sort_by(|a, b| a.0.cmp(&b.0));
+
+	let response = paginate_as_array(sorted_peers, page, limit, "/peers");
+	HttpResponse::Ok().json(response)
+}
+
+#[get("/peer_count")]
+async fn get_peer_count(app_state: web::Data<AppState>) -> impl Responder {
+	let server_list = app_state.server_list.lock().await;
+	let blacklist = app_state.blacklist.lock().await;
+
+	let counts = PeerCounts {
+		server_list_count: server_list.len(),
+		blacklist_count: blacklist.len(),
+	};
+
+	HttpResponse::Ok().json(counts)
+}
+pub async fn start_server(
+	blacklist: Arc<Mutex<HashMap<PeerId, ServerInfo>>>,
+	server_list: Arc<Mutex<HashMap<PeerId, ServerInfo>>>,
+	pagination_config: PaginationConfig,
+	http_port: u16,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+	let http_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, http_port));
+	info!("Starting HTTP server on {}", http_addr);
+
+	let app_state = web::Data::new(AppState {
+		blacklist: blacklist.clone(),
+		server_list: server_list.clone(),
+		config_pagination: pagination_config.clone(),
+	});
+
+	let server = HttpServer::new(move || {
+		App::new()
+			.app_data(app_state.clone())
+			.service(get_blacklisted_peers)
+			.service(get_peers)
+			.service(get_peer_count)
+	})
+	.bind(http_addr)
+	.expect("Failed to bind HTTP server");
+
+	match server.run().await {
+		Ok(_) => {
+			info!("HTTP server stopped");
+			Ok(())
+		},
+		Err(e) => {
+			error!("HTTP server error: {}", e);
+			Err(Box::new(e))
+		},
+	}
+}
+
+fn build_pagination_urls(
+	endpoint: &str,
+	page: usize,
+	limit: usize,
+	total_pages: usize,
+) -> (Option<String>, Option<String>) {
+	let next_page = if page < total_pages {
+		Some(format!("{}?page={}&limit={}", endpoint, page + 1, limit))
+	} else {
+		None
+	};
+
+	let prev_page = if page > 1 {
+		Some(format!("{}?page={}&limit={}", endpoint, page - 1, limit))
+	} else {
+		None
+	};
+
+	(next_page, prev_page)
+}
+
+fn paginate_as_array<T>(
+	items: Vec<(String, T)>,
+	page: usize,
+	limit: usize,
+	endpoint: &str,
+) -> PaginatedResponse<Vec<T>>
+where
+	T: Serialize,
+{
+	let total_items = items.len();
+	let total_pages = total_items.div_ceil(limit);
+	let start_index = (page - 1) * limit;
+
+	let (next_page, prev_page) = build_pagination_urls(endpoint, page, limit, total_pages);
+
+	let data: Vec<T> = items
+		.into_iter()
+		.skip(start_index)
+		.take(limit)
+		.map(|(_, value)| value)
+		.collect();
+
+	PaginatedResponse {
+		total_items,
+		total_pages,
+		current_page: page,
+		page_size: limit,
+		next_page,
+		prev_page,
+		data,
+	}
+}


### PR DESCRIPTION
- add REST API that exposes:
  - list of monitored peers
  - blackisted peers
  - total count of monitored peers

- exposed data is paginated, sorted by peerID