### PR TITLE
fix: yanked grcov dependency

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -50,8 +50,11 @@ jobs:
         env:
           RUSTFLAGS: "-C instrument-coverage"
           LLVM_PROFILE_FILE: "profile-%p-%m.profraw"
-      - name: Install grcov
-        run: cargo +stable install --force grcov
+      - uses: SierraSoftworks/setup-grcov@v1
+        name: Install grcov
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          version: latest
       - name: Generate test code coverage report
         run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o lcov.info
       - name: Upload test code coverage report to codecov.io


### PR DESCRIPTION
# Change
- [x] Switched grcov installation to a github action

# Reason for Change
Building from source is failing due to a yanked zip crate on v2.6.x. grcov team is trying to address this issue in the exact moment. In the meanwhile let's use a GHA to download pre-built binary.


Relevant PR:
- https://github.com/mozilla/grcov/pull/1352
