### PR TITLE
fix: Deletes shorthand http_port cli op

### DIFF
--- a/monitor-client/src/config.rs
+++ b/monitor-client/src/config.rs
@@ -39,7 +39,7 @@ pub struct CliOpts {
 	#[arg(short, long)]
 	pub p2p_port: Option<u16>,
 	/// REST server port
-	#[arg(short, long)]
+	#[arg(long)]
 	pub http_port: Option<u16>,
 	/// RocksDB store location
 	#[arg(long, default_value = "./db")]


### PR DESCRIPTION
# Changes
- [x] Deletes shorthand http_port cli op on avail-light-monitor bin

## Reason for change 
- There was a collision between short flags on `http_port` and `help` as seen in the panic below
- Removed the short flag notation to quick fix it.

```rust
╰─$ cargo run --bin avail-light-monitor 
   Compiling avail-light-monitor v0.1.0 (/avail-light/monitor-client)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 53.31s
     Running `/avail-light/target/debug/avail-light-monitor`

thread 'main' panicked at /.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.37/src/builder/debug_asserts.rs:112:17:
Command avail-light-monitor: Short option names must be unique for each argument, but '-h' is in use by both 'http_port' and 'help' (call `cmd.disable_help_flag(true)` to remove the auto-generated `--help`)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```