### PR TITLE
fix: API routes according to Docs

### DIFF
--- a/monitor-client/src/server.rs
+++ b/monitor-client/src/server.rs
@@ -60,7 +60,7 @@ pub struct AppState {
 	pub pagination: PaginationConfig,
 }
 
-#[get("/blacklisted_peers")]
+#[get("/peers/blacklisted")]
 async fn get_blacklisted_peers(
 	app_state: web::Data<AppState>,
 	pagination: web::Query<PaginationParams>,
@@ -191,7 +191,7 @@ async fn get_peer_by_id(app_state: web::Data<AppState>, path: web::Path<String>)
 	}))
 }
 
-#[get("/peer_count")]
+#[get("/peers/count")]
 async fn get_peer_count(app_state: web::Data<AppState>) -> impl Responder {
 	let server_list = app_state.server_list.lock().await;
 	let blacklist_count = server_list


### PR DESCRIPTION
# Changes
- API routes according to Docs

## Reason for change
- Monitor API peers `blacklist` and `count` routes are not matching docs and they fallback to `peer_id` route.

```json
╰─$ curl -s http://localhost:51241/peers/count
{"error":"Invalid peer ID format"}


╰─$ curl -s http://localhost:51241/peers/blacklisted
{"error":"Invalid peer ID format"}
```

## Local Tests
- cargo fmt :white_check_mark: 
- cargo check :white_check_mark: 
- cargo test :white_check_mark: 
- cargo build :white_check_mark: 