### PR TITLE
Naming and fat client

### DIFF
--- a/.github/workflows/avail-light-fatclient.yml
+++ b/.github/workflows/avail-light-fatclient.yml
@@ -16,28 +16,28 @@ jobs:
           - os: ubuntu-22.04
             workspace: avail-light-fat
             rust_target: x86_64-unknown-linux-gnu
-            output_name: avail-light-linux-amd64
+            output_name: avail-light-fat-linux-amd64
             extra_setup: |
               rustup target add x86_64-unknown-linux-gnu
 
           - os: macos-14
             workspace: avail-light-fat
             rust_target: aarch64-apple-darwin
-            output_name: avail-light-apple-arm64
+            output_name: avail-light-fat-apple-arm64
             extra_setup: |
               rustup target add aarch64-apple-darwin
 
           - os: macos-13
             workspace: avail-light-fat
             rust_target: x86_64-apple-darwin
-            output_name: avail-light-apple-x86_64
+            output_name: avail-light-fat-apple-x86_64
             extra_setup: |
               rustup target add x86_64-apple-darwin
 
           - os: windows-latest
             workspace: avail-light-fat
             rust_target: x86_64-pc-windows-msvc
-            output_name: avail-light-x86_64-pc-windows-msvc.exe
+            output_name: avail-light-fat-x86_64-pc-windows-msvc.exe
             extra_setup: |
               Invoke-WebRequest -Uri https://win.rustup.rs -OutFile rustup-init.exe
               .\rustup-init.exe -y --default-toolchain stable

--- a/.github/workflows/custom-release.yml
+++ b/.github/workflows/custom-release.yml
@@ -1,23 +1,28 @@
-name: Custom Release Components
+name: Manual pre-release
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to build from'
+        description: 'Branch'
         required: true
         default: 'main'
       version:
-        description: 'Version tag (e.g., v1.13.1, v1.13.1-alpha)'
+        description: 'Version (e.g. chore/upgrade, v1.13.1-alpha.1, v1.13.1-rc1)'
         required: true
       component:
-        description: 'Component to release'
+        description: 'Component'
         required: true
         type: choice
         options:
-          - bootnode
+          - all
           - lightclient
           - fatclient
-          - all
+          - bootnode
+      multiproof:
+        description: 'Multiproof feature'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
     build:
@@ -32,18 +37,22 @@ jobs:
         - name: Set release tag
           id: tag
           run: |
+            MMP_SUFFIX=""
+            if [ "${{ github.event.inputs.multiproof }}" = "true" ]; then
+              MMP_SUFFIX="-mmp"
+            fi
             case "${{ github.event.inputs.component }}" in
               "bootnode")
-                echo "tag=mmp-bootnode-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+                echo "tag=avail-light-bootstrap${MMP_SUFFIX}-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
                 ;;
               "lightclient")
-                echo "tag=mmp-lightclient-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+                echo "tag=avail-light-client${MMP_SUFFIX}-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
                 ;;
               "fatclient")
-                echo "tag=mmp-fatclient-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+                echo "tag=avail-light-fat${MMP_SUFFIX}-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
                 ;;
               "all")
-                echo "tag=mmp-all-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+                echo "tag=avail-light${MMP_SUFFIX}-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
                 ;;
             esac
 
@@ -73,7 +82,11 @@ jobs:
           if: ${{ github.event.inputs.component == 'lightclient' || github.event.inputs.component == 'all' }}
           run: |
             source "$HOME/.cargo/env"
-            cargo build --release --features multiproof -p avail-light-client
+            if [ "${{ github.event.inputs.multiproof }}" = "true" ]; then
+              cargo build --release --features multiproof -p avail-light-client
+            else
+              cargo build --release -p avail-light-client
+            fi
             mkdir -p binaries
             cp target/release/avail-light-client binaries/avail-light-linux-amd64
             cd binaries
@@ -83,14 +96,18 @@ jobs:
           if: ${{ github.event.inputs.component == 'fatclient' || github.event.inputs.component == 'all' }}
           run: |
             source "$HOME/.cargo/env"
-            cargo build --release -p avail-light-fat --features multiproof
+            if [ "${{ github.event.inputs.multiproof }}" = "true" ]; then
+              cargo build --release -p avail-light-fat --features multiproof
+            else
+              cargo build --release -p avail-light-fat
+            fi
             mkdir -p binaries
             ls -la target/release/
-            cp target/release/avail-light-fat binaries/avail-light-linux-amd64
+            cp target/release/avail-light-fat binaries/avail-light-fat-linux-amd64
             ls -la binaries/
-            ./binaries/avail-light-linux-amd64 --help
+            ./binaries/avail-light-fat-linux-amd64 --help
             cd binaries
-            tar czf avail-light-linux-amd64.tar.gz avail-light-linux-amd64
+            tar czf avail-light-fat-linux-amd64.tar.gz avail-light-fat-linux-amd64
 
         - name: Get commit changes
           id: changes
@@ -131,18 +148,22 @@ jobs:
         - name: Set release tag
           id: tag
           run: |
+            MMP_SUFFIX=""
+            if [ "${{ github.event.inputs.multiproof }}" = "true" ]; then
+              MMP_SUFFIX="-mmp"
+            fi
             case "${{ github.event.inputs.component }}" in
               "bootnode")
-                echo "tag=mmp-bootnode-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+                echo "tag=avail-light-bootstrap${MMP_SUFFIX}-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
                 ;;
               "lightclient")
-                echo "tag=mmp-lightclient-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+                echo "tag=avail-light-client${MMP_SUFFIX}-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
                 ;;
               "fatclient")
-                echo "tag=mmp-fatclient-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+                echo "tag=avail-light-fat${MMP_SUFFIX}-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
                 ;;
               "all")
-                echo "tag=mmp-all-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+                echo "tag=avail-light${MMP_SUFFIX}-${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
                 ;;
             esac
 


### PR DESCRIPTION
This PR:
- Gives `fat` suffix to the fat client binary, to allow releasing everything under the same release
- Reorders options to make `all` option default
- Introduces `multiproof` checkbox that enables related feature (and appends `mmp` suffix to releases)
- Wording changes to clarify UI 

Due to fat client binary naming changes, corresponding PR on `avail-light-infra` will be created.