### PR TITLE
fix: Adds pat token to avoid rate limit

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.PAT_TOKEN }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test --workspace --benches --tests --no-default-features
         env:


### PR DESCRIPTION
# Description
- [x] Adds pat token to avoid rate limit on GH API calls

## Reason for change
According to [arduino/setup-proc GHA](https://github.com/arduino/setup-protoc?tab=readme-ov-file#usage), public GH API calls are rate limited when not authenticated.